### PR TITLE
fix: don't overwrite ID at import (LANDA-49)

### DIFF
--- a/landa/organization_management/doctype/member/member.json
+++ b/landa/organization_management/doctype/member/member.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "autoname": "prompt",
  "creation": "2021-02-18 17:47:15.286220",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -210,7 +211,7 @@
    "link_fieldname": "member"
   }
  ],
- "modified": "2021-03-25 15:50:47.181245",
+ "modified": "2021-04-01 16:56:51.103396",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Member",

--- a/landa/organization_management/doctype/organization/organization.json
+++ b/landa/organization_management/doctype/organization/organization.json
@@ -2,6 +2,7 @@
  "actions": [],
  "allow_import": 1,
  "allow_rename": 1,
+ "autoname": "prompt",
  "creation": "2021-02-18 17:40:08.627933",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -184,7 +185,7 @@
    "link_fieldname": "organization"
   }
  ],
- "modified": "2021-03-30 21:48:34.581153",
+ "modified": "2021-04-01 16:53:36.208154",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Organization",


### PR DESCRIPTION
Import skips the Name / ID column except when autoname is set to "prompt". This workaround sets autoname to prompt, so IDs will be imported correctly. No dummy records needed.

Frappe still uses our autoname method to generate IDs for manually created entries, so this shouldn't have any effects otherwise.