### PR TITLE
fix: mark organization as treeview in hooks

### DIFF
--- a/landa/hooks.py
+++ b/landa/hooks.py
@@ -20,6 +20,8 @@ fixtures = [
 	{"dt": "Item", "filters": [["has_variants", "=", "1"]]},
 ]
 
+treeviews = ["Organization"]
+
 # Includes in <head>
 # ------------------
 


### PR DESCRIPTION
Wenn **Organization** aus dem Workspace oder über die Suche geöffnet wird, landet man direkt auf dem Tree-View.