### PR TITLE
feat: add dependencies to reports linked from workspace (LANDA-145)

### DIFF
--- a/landa/organization_management/workspace/order_management/order_management.json
+++ b/landa/organization_management/workspace/order_management/order_management.json
@@ -111,6 +111,7 @@
    "type": "Card Break"
   },
   {
+   "dependencies": "Delivery Note",
    "hidden": 0,
    "is_query_report": 1,
    "label": "Member Count",
@@ -120,6 +121,7 @@
    "type": "Link"
   },
   {
+   "dependencies": "Delivery Note",
    "hidden": 0,
    "is_query_report": 1,
    "label": "LANDA Deliveries and Payments",
@@ -129,7 +131,7 @@
    "type": "Link"
   }
  ],
- "modified": "2021-05-19 20:18:19.682012",
+ "modified": "2021-05-24 19:34:06.008624",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Order Management",

--- a/landa/organization_management/workspace/organization_management/organization_management.json
+++ b/landa/organization_management/workspace/organization_management/organization_management.json
@@ -76,6 +76,7 @@
    "type": "Card Break"
   },
   {
+   "dependencies": "Member",
    "hidden": 0,
    "is_query_report": 1,
    "label": "Member Address List",
@@ -85,6 +86,7 @@
    "type": "Link"
   },
   {
+   "dependencies": "Member",
    "hidden": 0,
    "is_query_report": 1,
    "label": "Member Birthday List",
@@ -94,6 +96,7 @@
    "type": "Link"
   },
   {
+   "dependencies": "Yearly Fishing Permit",
    "hidden": 0,
    "is_query_report": 0,
    "label": "Yearly Fishing Permits Issued",
@@ -129,7 +132,7 @@
    "type": "Link"
   }
  ],
- "modified": "2021-05-20 17:07:14.332858",
+ "modified": "2021-05-24 19:05:36.251819",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Organization Management",


### PR DESCRIPTION
- Disables link to report if no records exist yet
- Used to build the route to the Report Builder (required for #36)