### PR TITLE
feat: add user permission on company (LANDA-223)

### DIFF
--- a/landa/organization_management/doctype/landa_member/landa_member.py
+++ b/landa/organization_management/doctype/landa_member/landa_member.py
@@ -13,6 +13,7 @@ from frappe.model.naming import make_autoname
 from frappe.model.naming import revert_series_if_last
 from frappe.permissions import add_user_permission
 
+from landa.overrides import get_default_company
 from landa.organization_management.doctype.member_function.member_function import apply_active_member_functions
 from landa.organization_management.doctype.member_function_category.member_function_category import get_organization_at_level
 
@@ -59,7 +60,7 @@ class LANDAMember(Document):
 			self.email = None
 			self.create_user_account = False
 			self.save()
-			
+
 		if self.user and self.has_value_changed('user'):
 			self.create_user_permissions()
 			apply_active_member_functions({"member": self.name})
@@ -71,10 +72,13 @@ class LANDAMember(Document):
 	def create_user_permissions(self):
 		"""Restrict LANDA Member to itself and it's Organization."""
 		# LANDAMembers always have access at level 2 (Local Organization)
-		organization = get_organization_at_level(self.name, 2, self.organization)
-
 		add_user_permission("LANDA Member", self.name, self.user, ignore_permissions=True)
-		add_user_permission('Organization', organization, self.user, ignore_permissions=True)
+
+		organization = get_organization_at_level(self.name, 2, self.organization)
+		add_user_permission("Organization", organization, self.user, ignore_permissions=True)
+
+		company = get_default_company(self.organization)
+		add_user_permission("Company", company, self.user, ignore_permissions=True)
 
 	def revert_series(self):
 		"""Decrease the naming counter when the newest member gets deleted."""

--- a/landa/patches.txt
+++ b/landa/patches.txt
@@ -1,2 +1,3 @@
 landa.patches.checkbox_supporting_member
 landa.patches.rename_member_doctype
+landa.patches.add_user_perm_on_company

--- a/landa/patches/add_user_perm_on_company.py
+++ b/landa/patches/add_user_perm_on_company.py
@@ -1,0 +1,22 @@
+
+import frappe
+
+from landa.overrides import get_default_company
+from frappe.permissions import add_user_permission
+
+def execute():
+	"""Restrict all LANDA Members to their regional organization's company."""
+	members = frappe.get_all("LANDA Member",
+		fields=[
+			"organization",
+			"user"
+		],
+		filters={
+			"user": ("is", "set")
+		}
+	)
+
+	for member in members:
+		company = None
+		company = get_default_company(member.organization)
+		add_user_permission("Company", company, member.user, ignore_permissions=True)


### PR DESCRIPTION
Restrict all **LANDA Members** to records belonging to their own regional organization's company.

For example, a **LANDA Member** in "AVS-001" can only see the **Item Tax Templates** linked to the **Company** "AVS", not the ones linked to "AVL".

Applies to all existing and new **LANDA Members**.