### PR TITLE
feat: add permission to use custom reports (LANDA-375)

### DIFF
--- a/landa/fixtures/custom_docperm.json
+++ b/landa/fixtures/custom_docperm.json
@@ -1,0 +1,29 @@
+[
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 0,
+  "export": 1,
+  "if_owner": 1,
+  "import": 0,
+  "modified": "2021-11-04 19:23:05.306811",
+  "name": "bbcf4d71c1",
+  "parent": "Report",
+  "parentfield": "permissions",
+  "parenttype": "DocType",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "LANDA Regional Organization Management",
+  "select": 1,
+  "set_user_permissions": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
+ }
+]

--- a/landa/hooks.py
+++ b/landa/hooks.py
@@ -24,8 +24,20 @@ fixtures = [
 	"Fish Species",
 	"Fishing Area",
 	"Item Attribute",
-	{"dt": "Variant Field", "filters": [["field_name", "in", ["description", "item_tax_template"]]]},
-	"Translation"
+	{
+		"dt": "Variant Field",
+		"filters": [["field_name", "in", ["description", "item_tax_template"]]],
+	},
+	"Translation",
+	{
+		# export custom permission as fixture because Report is a core doctype
+		# and cannot be customized via customize form
+		"dt": "Custom DocPerm",
+		"filters": [
+			["role", "=", "LANDA Regional Organization Management"],
+			["parent", "=", "Report"],
+		],
+	},
 ]
 
 # DocTypes to be created once, after installation of this app


### PR DESCRIPTION
Add permission to create custom reports to role _LANDA Regional Organization Management_.

![Bildschirmfoto 2021-11-04 um 19 38 45](https://user-images.githubusercontent.com/14891507/140400017-3547e211-2393-4cba-981f-7743bd757662.png)

Frappe [validiert selber](https://github.com/frappe/frappe/blob/b76f79c06c10854fd0751b7916f294fe60c3794f/frappe/core/doctype/report/report.py#L30-L31), dass hier niemand heimlich SQL-Abfragen einbaut.