### PR TITLE
fix: cannot create Yearly Fishing Permit Type if it already exists in Item Attribute (LANDA-479)

### DIFF
--- a/landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.json
+++ b/landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.json
@@ -103,7 +103,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "type.yearly_fishing_permit_type_name",
+   "fetch_from": "type.title",
    "fieldname": "type_name",
    "fieldtype": "Data",
    "label": "Type Name",
@@ -113,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-13 17:37:02.047447",
+ "modified": "2021-12-21 15:10:02.047447",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Yearly Fishing Permit",

--- a/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.json
+++ b/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.json
@@ -15,7 +15,8 @@
   {
    "fieldname": "yearly_fishing_permit_type_name",
    "fieldtype": "Data",
-   "label": "Yearly Fishing Permit Type Name"
+   "label": "Yearly Fishing Permit Type Name",
+   "unique": 1
   },
   {
    "fieldname": "short_code",
@@ -41,7 +42,7 @@
    "link_fieldname": "type"
   }
  ],
- "modified": "2021-10-04 15:08:55.268764",
+ "modified": "2021-12-20 17:32:42.883458",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Yearly Fishing Permit Type",

--- a/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.json
+++ b/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.json
@@ -1,29 +1,17 @@
 {
  "actions": [],
  "allow_import": 1,
- "autoname": "field:short_code",
+ "autoname": "Prompt",
  "creation": "2021-04-26 17:50:19.649303",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "yearly_fishing_permit_type_name",
-  "short_code",
+  "title",
+  "item_attribute",
   "amended_from"
  ],
  "fields": [
-  {
-   "fieldname": "yearly_fishing_permit_type_name",
-   "fieldtype": "Data",
-   "label": "Yearly Fishing Permit Type Name",
-   "unique": 1
-  },
-  {
-   "fieldname": "short_code",
-   "fieldtype": "Data",
-   "label": "Short Code",
-   "unique": 1
-  },
   {
    "fieldname": "amended_from",
    "fieldtype": "Link",
@@ -32,6 +20,23 @@
    "options": "Yearly Fishing Permit Type",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "default": "Erlaubnisscheinart",
+   "fieldname": "item_attribute",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Attribute",
+   "options": "Item Attribute",
+   "reqd": 1
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1,
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -42,10 +47,11 @@
    "link_fieldname": "type"
   }
  ],
- "modified": "2021-12-20 17:32:42.883458",
+ "modified": "2021-12-20 18:15:08.319425",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Yearly Fishing Permit Type",
+ "name_case": "UPPER CASE",
  "owner": "Administrator",
  "permissions": [
   {
@@ -91,6 +97,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "title_field": "yearly_fishing_permit_type_name",
+ "title_field": "title",
  "track_changes": 1
 }

--- a/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.py
+++ b/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.py
@@ -23,20 +23,29 @@ def add_attribute_value(name, attribute_value, abbr):
 	create_item_attribute(name)
 	item_attr = frappe.get_doc("Item Attribute", name)
 	item_attr_link = get_link_to_form(item_attr.doctype, item_attr.name)
+	item_attribute_values = [(row.attribute_value, row.abbr) for row in item_attr.item_attribute_values]
 
-	existing_values = [row.attribute_value for row in item_attr.item_attribute_values]
-	existing_abbreviations = [row.abbr for row in item_attr.item_attribute_values]
+	existing_pairs = [row for row in item_attribute_values if row == (attribute_value, abbr)]
+	if existing_pairs:
+		# Item attribute exists already, as intended
+		return
+
+	existing_values = [row[0] for row in item_attribute_values]
+	existing_abbreviations = [row[1] for row in item_attribute_values]
 
 	if attribute_value in existing_values:
+		# Attribute value exists, but with a different abbreviation
 		frappe.throw(_('Value "{}" exists already in Item Attribute {}.').format(attribute_value, item_attr_link))
-	elif abbr in existing_abbreviations:
+
+	if abbr in existing_abbreviations:
+		# Abbreviation exists, but with a different attribute value
 		frappe.throw(_('Abbreviation "{}" exists already in Item Attribute {}.').format(abbr, item_attr_link))
-	else:
-		item_attr.append('item_attribute_values', {
-			'attribute_value': attribute_value,
-			'abbr': abbr
-		})
-		item_attr.save()
+
+	item_attr.append('item_attribute_values', {
+		'attribute_value': attribute_value,
+		'abbr': abbr
+	})
+	item_attr.save()
 
 
 def create_item_attribute(name):

--- a/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.py
+++ b/landa/organization_management/doctype/yearly_fishing_permit_type/yearly_fishing_permit_type.py
@@ -8,49 +8,57 @@ from frappe import _
 from frappe.utils.data import get_link_to_form
 from frappe.model.document import Document
 
+
 class YearlyFishingPermitType(Document):
-	def before_insert(self):
-		self.short_code = self.short_code.upper()
+	def validate(self):
+		validate_item_attribute(self.item_attribute, self.title, self.name)
 
 	def on_submit(self):
-		add_attribute_value(
-			"Erlaubnisscheinart",
-			self.yearly_fishing_permit_type_name,
-			self.short_code
-		)
+		add_attribute_value(self.item_attribute, self.title, self.name)
 
-def add_attribute_value(name, attribute_value, abbr):
-	create_item_attribute(name)
-	item_attr = frappe.get_doc("Item Attribute", name)
-	item_attr_link = get_link_to_form(item_attr.doctype, item_attr.name)
-	item_attribute_values = [(row.attribute_value, row.abbr) for row in item_attr.item_attribute_values]
 
-	existing_pairs = [row for row in item_attribute_values if row == (attribute_value, abbr)]
-	if existing_pairs:
+def validate_item_attribute(item_attribute_name, attribute_value, abbr):
+	item_attr = frappe.get_doc("Item Attribute", item_attribute_name)
+	item_attribute_values = rows_to_tuples(item_attr.item_attribute_values)
+
+	if (attribute_value, abbr) in item_attribute_values:
 		# Item attribute exists already, as intended
 		return
 
 	existing_values = [row[0] for row in item_attribute_values]
 	existing_abbreviations = [row[1] for row in item_attribute_values]
+	item_attr_link = get_link_to_form(item_attr.doctype, item_attr.name)
 
 	if attribute_value in existing_values:
 		# Attribute value exists, but with a different abbreviation
-		frappe.throw(_('Value "{}" exists already in Item Attribute {}.').format(attribute_value, item_attr_link))
+		frappe.throw(
+			_('Value "{}" exists already in Item Attribute {}.').format(
+				attribute_value, item_attr_link
+			)
+		)
 
 	if abbr in existing_abbreviations:
 		# Abbreviation exists, but with a different attribute value
-		frappe.throw(_('Abbreviation "{}" exists already in Item Attribute {}.').format(abbr, item_attr_link))
+		frappe.throw(
+			_('Abbreviation "{}" exists already in Item Attribute {}.').format(
+				abbr, item_attr_link
+			)
+		)
 
-	item_attr.append('item_attribute_values', {
-		'attribute_value': attribute_value,
-		'abbr': abbr
-	})
+
+def rows_to_tuples(rows):
+	return [(row.attribute_value, row.abbr) for row in rows]
+
+
+def add_attribute_value(item_attribute_name, attribute_value, abbr):
+	"""Add a row (attribute_value, abbr) to Item Attibute."""
+	item_attr = frappe.get_doc("Item Attribute", item_attribute_name)
+	item_attribute_values = rows_to_tuples(item_attr.item_attribute_values)
+	if (attribute_value, abbr) in item_attribute_values:
+		# Item attribute exists already, as intended
+		return
+
+	item_attr.append(
+		"item_attribute_values", {"attribute_value": attribute_value, "abbr": abbr}
+	)
 	item_attr.save()
-
-
-def create_item_attribute(name):
-	"""Create an Item Attribute if there isn't one already"""
-	if not frappe.db.exists("Item Attribute", name):
-		item_attr = frappe.new_doc("Item Attribute")
-		item_attr.attribute_name = name
-		item_attr.insert()


### PR DESCRIPTION
- Fehlermeldungen kommen jetzt direkt, noch bevor der **Yearly Fishing Permit Type** gespeichert werden kann.
- Wenn ein **Yearly Fishing Permit Type** erstellt wird, der genau so im **Item Attribute** schon existiert, ist das jetzt erlaubt.
- **Item Attribute** wird jetzt im  **Yearly Fishing Permit Type** verlinkt. So müssen wir nicht mehr prüfen, ob es schon existiert und den Namen nicht mehr hart kodieren.