### PR TITLE
fix: broken bracket } in previous commit

### DIFF
--- a/landa/hooks.py
+++ b/landa/hooks.py
@@ -48,7 +48,7 @@ fixtures = [
 	},
 	"Salutation",
 	"Gender",
-   {"dt": "Note", "filters": {"name": "Datenschutz Hinweise"},
+   {"dt": "Note", "filters": {"name": "Datenschutz Hinweise"}},
 ]
 
 


### PR DESCRIPTION
@barredterra Sorry, ich hatte deine Änderung angenommen, gemerget und vorher nicht getestet...

Ich habe die Klammer repariert, aber es gibt ein weiteres Problem: 

Ich habe die neueste Frappe und ERPNext Version installiert und vermutlich aus Versehen einen noch benötigten hotfix übersprungen.

Der Administrator erhält mit diesem Branch und aktueller Frappe + ERPNext Version immer den Hinweis, dass er keinen Zugang zu Listen, z. B. Mitglied hat. Schließt man den Hinweis, geht aber alles:

```
02:12:00 web.1            | 127.0.0.1 - - [04/Jan/2022 02:12:00] "GET /api/method/frappe.desk.reportview.get_sidebar_stats?stats=%5B%22_user_tags%22%5D&doctype=LANDA+Member&filters=%5B%5D&_=1641258706025 HTTP/1.1" 200 -
02:12:06 web.1            | Traceback (most recent call last):
02:12:06 web.1            |   File "apps/frappe/frappe/app.py", line 68, in application
02:12:06 web.1            |     response = frappe.api.handle()
02:12:06 web.1            |   File "apps/frappe/frappe/api.py", line 55, in handle
02:12:06 web.1            |     return frappe.handler.handle()
02:12:06 web.1            |   File "apps/frappe/frappe/handler.py", line 31, in handle
02:12:06 web.1            |     data = execute_cmd(cmd)
02:12:06 web.1            |   File "apps/frappe/frappe/handler.py", line 64, in execute_cmd
02:12:06 web.1            |     is_whitelisted(method)
02:12:06 web.1            |   File "apps/frappe/frappe/__init__.py", line 608, in is_whitelisted
02:12:06 web.1            |     throw(_("Not permitted"), PermissionError)
02:12:06 web.1            |   File "apps/frappe/frappe/__init__.py", line 439, in throw
02:12:06 web.1            |     msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
02:12:06 web.1            |   File "apps/frappe/frappe/__init__.py", line 418, in msgprint
02:12:06 web.1            |     _raise_exception()
02:12:06 web.1            |   File "apps/frappe/frappe/__init__.py", line 372, in _raise_exception
02:12:06 web.1            |     raise raise_exception(msg)
02:12:06 web.1            | frappe.exceptions.PermissionError: Nicht gestattet
02:12:06 web.1            | 
02:12:06 web.1            | 127.0.0.1 - - [04/Jan/2022 02:12:06] "POST /api/method/frappe.deferred_insert.deferred_insert HTTP/1.1" 403 -
```

<img width="895" alt="image" src="https://user-images.githubusercontent.com/79863208/147996996-832d48e0-d0db-49b0-9857-02de8cbc86e9.png">
