### PR TITLE
feat: restrict fishing area in organization (LANDA-562)

### DIFF
--- a/landa/organization_management/doctype/organization/organization.js
+++ b/landa/organization_management/doctype/organization/organization.js
@@ -2,6 +2,27 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Organization', {
+    onload: function(frm) {
+        frm.trigger('set_fishing_area_query')
+    },
+    set_fishing_area_query: function(frm) {
+        if (!frm.doc.parent_organization || frm.doc.parent_organization === 'LV') {
+            // If we're in a state or regional Organization, this doesn't make
+            // sense because Fishing Area depends on regional Organization.
+            return;
+        }
+
+        // allow only fishing areas within the own regional organization
+        frm.set_query('fishing_area', function(doc) {
+            return {
+                filters: {
+                    // own regional organization is determined by the first
+                    // three letters of the parent organization
+                    organization: doc.parent_organization.substring(0, 3),
+                },
+            };
+        });
+    },
     refresh: function(frm) {
         // Automatically add the backlink to Organization when a new Address or
         // Contact is added.

--- a/landa/organization_management/doctype/organization/organization.json
+++ b/landa/organization_management/doctype/organization/organization.json
@@ -103,6 +103,9 @@
    "label": "Location"
   },
   {
+   "depends_on": "eval:doc.parent_organization && doc.parent_organization !== 'LV';",
+   "fetch_from": "parent_organization.fishing_area",
+   "fetch_if_empty": 1,
    "fieldname": "fishing_area",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -263,7 +266,7 @@
    "link_fieldname": "organization"
   }
  ],
- "modified": "2022-03-11 15:02:35.352043",
+ "modified": "2022-03-17 18:51:42.552666",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Organization",
@@ -316,41 +319,25 @@
    "write": 1
   },
   {
-   "export": 1,
    "permlevel": 1,
    "read": 1,
-   "report": 1,
    "role": "LANDA Member"
   },
   {
-   "export": 1,
    "permlevel": 1,
    "read": 1,
-   "report": 1,
    "role": "LANDA Local Organization Management"
   },
   {
-   "delete": 1,
-   "email": 1,
-   "export": 1,
    "permlevel": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
    "role": "LANDA State Organization Employee",
-   "share": 1,
    "write": 1
   },
   {
-   "delete": 1,
-   "email": 1,
-   "export": 1,
    "permlevel": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
    "role": "LANDA Regional Organization Management",
-   "share": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
@barredterra Ich habe versucht, das Feld Region im DocType Verein für Vereine als read-only zu setzen und nur von RV und LV bearbeiten zu lassen.
Das Feld Region verschwindet aber für Vereinsnutzer. Von mir aus gerne korrigieren und direkt mergen.

- hide fishing area for state and regional org
- restrict fishing area to own regional organization
- fetch fishing area from parent organization (for Ortsgruppen)