### PR TITLE
Reduce Connections in Sales Order, Remove Link to Payment Entry (LANDA-711 / LAN-573)

### DIFF
--- a/landa/hooks.py
+++ b/landa/hooks.py
@@ -326,9 +326,9 @@ override_whitelisted_methods = {
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
-# override_doctype_dashboards = {
-#	"Task": "landa.task.get_dashboard_data"
-# }
+override_doctype_dashboards = {
+	"Sales Order": "landa.landa_sales.sales_order.sales_order.get_dashboard_data"
+}
 
 # exempt linked doctypes from being automatically cancelled
 #

--- a/landa/landa_sales/sales_order/sales_order.py
+++ b/landa/landa_sales/sales_order/sales_order.py
@@ -18,8 +18,20 @@ def before_validate(sales_order, event):
 	):
 		sales_order.tax_category = "Umsatzsteuer"
 
+
 def autoname(doc, event):
 	"""Create Company-specific Sales Order name."""
 	from landa.utils import get_new_name
 
 	doc.name = get_new_name("BEST", doc.company, "Sales Order")
+
+
+def get_dashboard_data(data):
+	custom_transactions = [
+		{
+			"label": "Sales",
+			"items": ["Delivery Note", "Sales Invoice"],
+		}
+	]
+	data["transactions"] = custom_transactions
+	return data

--- a/landa/landa_sales/sales_order/sales_order.py
+++ b/landa/landa_sales/sales_order/sales_order.py
@@ -27,11 +27,10 @@ def autoname(doc, event):
 
 
 def get_dashboard_data(data):
-	custom_transactions = [
+	data["transactions"] = [
 		{
 			"label": "Sales",
 			"items": ["Delivery Note", "Sales Invoice"],
-		}
+		},
 	]
-	data["transactions"] = custom_transactions
 	return data


### PR DESCRIPTION
I considered removing the link between the two DocTypes but decided there is a chance we want to use this link in the future (e.g. when orders are automated) so I just hid the connections of Sales Order and left everything else.