### PR TITLE
feat: set primary phone and email while validating contact (LAN-200)

### DIFF
--- a/landa/hooks.py
+++ b/landa/hooks.py
@@ -278,7 +278,10 @@ doc_events = {
 		"autoname": "landa.organization_management.address.address.autoname",
 	},
 	"Contact": {
-		"validate": "landa.address_and_contact.validate",
+		"validate": [
+			"landa.organization_management.contact.contact.validate",
+			"landa.address_and_contact.validate"
+		],
 		"after_insert": "landa.organization_management.contact.contact.after_insert",
 	},
 }

--- a/landa/organization_management/contact/contact.py
+++ b/landa/organization_management/contact/contact.py
@@ -1,6 +1,7 @@
+from frappe.contacts.doctype.contact.contact import Contact
 
 
-def after_insert(contact, event):
+def after_insert(contact: Contact, event: str) -> None:
 	"""
 	Delete Contact if it's linked to User.
 
@@ -9,3 +10,50 @@ def after_insert(contact, event):
 	"""
 	if contact.user:
 		contact.delete()
+
+
+def validate(contact: Contact, event: str) -> None:
+	set_primary_email_if_missing(contact)
+	set_primary_phone_if_missing(contact)
+
+
+def set_primary_email_if_missing(contact: Contact) -> bool:
+	"""If no email_id is set as primary for a contact, set the first email_id as primary"""
+	if not contact.email_ids or value_is_set(contact.email_ids, "is_primary"):
+		return False
+
+	contact.email_ids[0].is_primary = 1
+	return True
+
+
+def set_primary_phone_if_missing(contact: Contact) -> bool:
+	"""If no phone is set as primary mobile or primary phone for a contact,
+	set the first mobile as primary mobile and the first not mobile as primary phone
+	(according to the first digits of the phone number)"""
+	modified = False
+	if not contact.phone_nos:
+		return modified
+
+	if not value_is_set(contact.phone_nos, "is_primary_mobile_no"):
+		for phone in contact.phone_nos:
+			if is_mobile_number(phone.phone):
+				phone.is_primary_mobile_no = 1
+				modified = True
+				break
+
+	if not value_is_set(contact.phone_nos, "is_primary_phone"):
+		for phone in contact.phone_nos:
+			if not is_mobile_number(phone.phone):
+				phone.is_primary_phone = 1
+				modified = True
+				break
+
+	return modified
+
+
+def value_is_set(rows: list, fieldname: str) -> bool:
+	return any(row.get(fieldname) for row in rows)
+
+
+def is_mobile_number(number: str) -> bool:
+	return "".join(filter(str.isdigit, number)).startswith(("01", "491", "00491"))

--- a/landa/patches/set_phone_and_email_as_primary.py
+++ b/landa/patches/set_phone_and_email_as_primary.py
@@ -1,6 +1,10 @@
 import frappe
-from frappe.contacts.doctype.contact.contact import Contact
 from frappe.utils import update_progress_bar
+
+from landa.organization_management.contact.contact import (
+	set_primary_email_if_missing,
+	set_primary_phone_if_missing,
+)
 
 
 def execute():
@@ -25,45 +29,3 @@ def execute():
 			contact.save(ignore_permissions=True, ignore_version=True)
 
 	frappe.db.auto_commit_on_many_writes = False
-
-
-def value_is_set(rows: list, fieldname: str) -> bool:
-	return any(row.get(fieldname) for row in rows)
-
-
-def number_is_mobile(number: str) -> bool:
-	return "".join(filter(str.isdigit, number)).startswith(("01", "491", "00491"))
-
-
-def set_primary_email_if_missing(contact: Contact) -> bool:
-	"""If no email_id is set as primary for a contact, set the first email_id as primary"""
-	if not contact.email_ids or value_is_set(contact.email_ids, "is_primary"):
-		return False
-
-	contact.email_ids[0].is_primary = 1
-	return True
-
-
-def set_primary_phone_if_missing(contact: Contact) -> bool:
-	"""If no phone is set as primary mobile or primary phone for a contact,
-	set the first mobile as primary mobile and the first not mobile as primary phone
-	(according to the first digits of the phone number)"""
-	modified = False
-	if not contact.phone_nos:
-		return modified
-
-	if not value_is_set(contact.phone_nos, "is_primary_mobile_no"):
-		for phone in contact.phone_nos:
-			if number_is_mobile(phone.phone):
-				phone.is_primary_mobile_no = 1
-				modified = True
-				break
-
-	if not value_is_set(contact.phone_nos, "is_primary_phone"):
-		for phone in contact.phone_nos:
-			if not number_is_mobile(phone.phone):
-				phone.is_primary_phone = 1
-				modified = True
-				break
-
-	return modified


### PR DESCRIPTION
Slightly different implementation than requested – if no primary is set, we just set the first one as primary. It is easy to change by the user and saves us a demotivating error message.