### PR TITLE
fix: Disable sharing via the browser triggered events (LAN-737)

### DIFF
--- a/landa/api_overrides/share.py
+++ b/landa/api_overrides/share.py
@@ -1,0 +1,48 @@
+import frappe
+from frappe import _
+
+from frappe.desk.form.document_follow import follow_document
+from frappe.share import get_share_name, notify_assignment
+from frappe.utils import cint
+
+
+@frappe.whitelist()
+def add(
+	doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, flags=None, notify=0
+):
+	"""Share the given document with a user."""
+	if not user:
+		user = frappe.session.user
+
+	if not (flags or {}).get("ignore_share_permission"):
+		frappe.throw(_("Not permitted to share {0}").format(doctype))
+
+	share_name = get_share_name(doctype, name, user, everyone)
+
+	if share_name:
+		doc = frappe.get_doc("DocShare", share_name)
+	else:
+		doc = frappe.new_doc("DocShare")
+		doc.update(
+			{"user": user, "share_doctype": doctype, "share_name": name, "everyone": cint(everyone)}
+		)
+
+	if flags:
+		doc.flags.update(flags)
+
+	doc.update(
+		{
+			# always add read, since you are adding!
+			"read": 1,
+			"write": cint(write),
+			"submit": cint(submit),
+			"share": cint(share),
+		}
+	)
+
+	doc.save(ignore_permissions=True)
+	notify_assignment(user, doctype, name, everyone, notify=notify)
+
+	follow_document(doctype, name, user)
+
+	return doc

--- a/landa/hooks.py
+++ b/landa/hooks.py
@@ -330,7 +330,8 @@ override_whitelisted_methods = {
 	"erpnext.selling.doctype.sales_order.sales_order.make_delivery_note": "landa.landa_sales.sales_order.sales_order.make_landa_delivery_note",
 	"erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice": "landa.landa_sales.sales_order.sales_order.make_landa_sales_invoice",
 	"erpnext.accounts.doctype.sales_invoice.sales_invoice.make_delivery_note": "landa.landa_sales.sales_invoice.sales_invoice.make_landa_delivery_note",
-	"erpnext.stock.doctype.delivery_note.delivery_note.make_sales_invoice": "landa.landa_stock.delivery_note.delivery_note.make_landa_sales_invoice"	
+	"erpnext.stock.doctype.delivery_note.delivery_note.make_sales_invoice": "landa.landa_stock.delivery_note.delivery_note.make_landa_sales_invoice",
+	"frappe.share.add": "landa.api_overrides.share.add"
 }
 
 #


### PR DESCRIPTION
**Sharing via UI:**
![2023-03-09 21 38 16](https://user-images.githubusercontent.com/25857446/224084675-874b78f0-1b54-4363-84cd-6729d193fba6.gif)

**Sharing via API call:**
<img width="1435" alt="Screenshot 2023-03-09 at 9 40 30 PM" src="https://user-images.githubusercontent.com/25857446/224084785-bd29eb96-2523-4479-8877-a6cfba9a351e.png">

**User creation works fine:**
![2023-03-09 21 46 56](https://user-images.githubusercontent.com/25857446/224085739-ef712392-065a-4a98-bd88-eb3945d13d64.gif)

