### PR TITLE
feat: don't edit water body of other regional org (LAN-602)

### DIFF
--- a/landa/translations/de.csv
+++ b/landa/translations/de.csv
@@ -4,3 +4,4 @@ You cannot delete your own user account.,Sie können Ihr eigenes Benutzerkonto n
 You cannot delete standard user.,Sie können Standardbenutzer nicht löschen.,
 Deleting {0}...,Lösche {0}...,
 Deleting {0} records...,Lösche {0} Datensätze...,
+You can only edit a Water Body if it belongs to your regional Organization.,"Sie können ein Gewässer nur bearbeiten, wenn es zu Ihrem Regionalverband gehört.",

--- a/landa/water_body_management/doctype/water_body/water_body.js
+++ b/landa/water_body_management/doctype/water_body/water_body.js
@@ -1,8 +1,14 @@
 // Copyright (c) 2021, Real Experts GmbH and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Water Body', {
-	// refresh: function(frm) {
-
-	// }
+frappe.ui.form.on("Water Body", {
+	refresh: function (frm) {
+		if (
+			!frm.is_new() &&
+			frappe.boot.landa.regional_organization &&
+			frm.doc.organization !== frappe.boot.landa.regional_organization
+		) {
+			frm.disable_form();
+		}
+	},
 });

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -3,8 +3,21 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+
+import frappe
+from frappe import _
 from frappe.model.document import Document
+from landa.utils import get_current_member_data
+
 
 class WaterBody(Document):
-	pass
+	def validate(self):
+		current_member_data = get_current_member_data()
+		if current_member_data.regional_organization and (
+			self.organization != current_member_data.regional_organization
+		):
+			frappe.throw(
+				_(
+					"You can only edit a Water Body if it belongs to your regional Organization."
+				)
+			)


### PR DESCRIPTION
Users are not allowed to edit a Water Body if it belongs to a different regional Organization.

- Disable form view
- Validate in backend
- Admin (not tied to a regional Organization) is not affected