### PR TITLE
fix: Use `make_methods` to keep custom btn & dashboard behaviour consistent (LAN-748)

### DIFF
--- a/landa/organization_management/doctype/landa_member/landa_member.js
+++ b/landa/organization_management/doctype/landa_member/landa_member.js
@@ -11,6 +11,17 @@ frappe.ui.form.on("LANDA Member", {
 				},
 			};
 		});
+
+		frm.make_methods = {
+			"User": () => {
+				frappe.new_doc("User", {
+					first_name: frm.doc.first_name,
+					last_name: frm.doc.last_name,
+					landa_member: frm.doc.name,
+					organization: frm.doc.organization,
+				});
+			}
+		}
 	},
 	refresh: function (frm) {
 		// Automatically add the backlink to LANDA Member when a new Address or
@@ -37,21 +48,8 @@ frappe.ui.form.on("LANDA Member", {
 					.then((resp) => {
 						if (resp.message.name) return;
 
-						// prefill the user form when created via dashboard "+" button
-						frappe.route_options = {
-							first_name: frm.doc.first_name,
-							last_name: frm.doc.last_name,
-							landa_member: frm.doc.name,
-							organization: frm.doc.organization,
-						};
-
 						frm.add_custom_button(__("Create User"), function () {
-							frappe.new_doc("User", {
-								first_name: frm.doc.first_name,
-								last_name: frm.doc.last_name,
-								landa_member: frm.doc.name,
-								organization: frm.doc.organization,
-							});
+							frm.make_methods["User"]();
 						});
 					});
 			});


### PR DESCRIPTION
**Working:**
![2023-04-07 13 53 26](https://user-images.githubusercontent.com/25857446/230572341-0e91204f-57dc-4090-9ac0-36fc551e6c16.gif)

------------------------

> we currently set frappe.route_options. However, this also pre-fills data when navigating to other views (for example, it sets the filters when navigating back to the member list view). 

I could not really replicate this but shifted to `make_methods` anyway, it's cleaner.