### PR TITLE
perf: Make Water Body API Performant (LAN-769)

### DIFF
--- a/landa/patches.txt
+++ b/landa/patches.txt
@@ -23,3 +23,4 @@ landa.patches.set_billing_and_shipping_defaults
 landa.patches.delete_old_scheduled_job_logs
 landa.patches.update_system_settings
 landa.patches.delete_customized_workspaces  # 2023-06-06
+landa.patches.build_water_body_cache

--- a/landa/patches/build_water_body_cache.py
+++ b/landa/patches/build_water_body_cache.py
@@ -1,0 +1,11 @@
+import frappe
+
+from landa.water_body_management.doctype.water_body.water_body import build_water_body_cache
+
+
+def execute():
+	build_water_body_cache()  # Cache all Water Bodies
+
+	fishing_areas = frappe.get_all("Fishing Area", pluck="name")
+	for area in fishing_areas:
+		build_water_body_cache(fishing_area=area)  # Cache Fishing Area wise

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -13,10 +13,10 @@ from landa.utils import get_current_member_data
 
 class WaterBody(Document):
 	def on_update(self):
-		self.rebuild_water_body_cache()
+		rebuild_water_body_cache(self.fishing_area)
 
 	def on_trash(self):
-		self.rebuild_water_body_cache()
+		rebuild_water_body_cache(self.fishing_area)
 
 	def validate(self):
 		self.validate_edit_access()
@@ -42,14 +42,18 @@ class WaterBody(Document):
 					title=_("Invalid Species"),
 				)
 
-	def rebuild_water_body_cache(self):
-		# Invalidate Cache
-		frappe.cache().hdel("water_body_data", "all")
-		frappe.cache().hdel("water_body_data", self.fishing_area)
 
-		# Build Cache for all water bodies and fishing area wise
-		build_water_body_cache()
-		build_water_body_cache(fishing_area=self.fishing_area)
+def rebuild_water_body_cache(fishing_area: str = None):
+	"""
+	Rebuilds water body cache for all water bodies **AND** fishing area wise.
+	"""
+	# Invalidate Cache
+	frappe.cache().hdel("water_body_data", "all")
+	build_water_body_cache()
+
+	if fishing_area:
+		frappe.cache().hdel("water_body_data", fishing_area)
+		build_water_body_cache(fishing_area=fishing_area)
 
 
 def remove_outdated_information():

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021, Real Experts GmbH and contributors
 # For license information, please see license.txt
 from collections import defaultdict
+from json import loads
 from typing import Dict, List
 
 import frappe
@@ -171,9 +172,10 @@ def consolidate_water_body_data(water_body_data: List[Dict]) -> List[Dict]:
 def init_row(water_body_row: Dict) -> Dict:
 	# Prepare row to have Water Body data (excluding child tables)
 	water_body_copy = water_body_row.copy()
+	location = water_body_copy.pop("location", None)
 
-	if water_body_copy.location:
-		water_body_copy["geojson"] = frappe.parse_json(water_body_copy.location)
+	if location and isinstance(location, str):
+		water_body_copy["geojson"] = loads(location)
 
 	for field in (
 		"fish_species",

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2021, Real Experts GmbH and contributors
 # For license information, please see license.txt
-
+from typing import Dict, List
 
 import frappe
 from frappe import _
@@ -11,6 +11,12 @@ from landa.utils import get_current_member_data
 
 
 class WaterBody(Document):
+	def on_update(self):
+		self.rebuild_water_body_cache()
+
+	def on_trash(self):
+		self.rebuild_water_body_cache()
+
 	def validate(self):
 		self.validate_edit_access()
 		self.validate_blacklisted_fish_species()
@@ -35,6 +41,15 @@ class WaterBody(Document):
 					title=_("Invalid Species"),
 				)
 
+	def rebuild_water_body_cache(self):
+		# Invalidate Cache
+		frappe.cache().hdel("water_body_data", "all")
+		frappe.cache().hdel("water_body_data", self.fishing_area)
+
+		# Build Cache for all water bodies and fishing area wise
+		build_water_body_cache()
+		build_water_body_cache(fishing_area=self.fishing_area)
+
 
 def remove_outdated_information():
 	for name in frappe.get_all(
@@ -49,3 +64,66 @@ def remove_outdated_information():
 		water_body.current_public_information = None
 		water_body.current_information_expires_on = None
 		water_body.save()
+
+
+def build_water_body_cache(fishing_area: str = None):
+	"""Build the water body cache for all water bodies **OR** fishing area wise."""
+	water_bodies = build_water_body_data(fishing_area=fishing_area)
+	frappe.cache().hset("water_body_data", fishing_area, water_bodies)
+
+
+def build_water_body_data(id: str = None, fishing_area: str = None) -> List[Dict]:
+	"""Return a list of water bodies with fish species and special provisions."""
+	filters = [
+		["Water Body", "is_active", "=", 1],
+		["Water Body", "display_in_fishing_guide", "=", 1],
+	]
+	if id and isinstance(id, str):
+		filters.append(["Water Body", "name", "=", id])
+
+	if fishing_area and isinstance(fishing_area, str):
+		filters.append(["Water Body", "fishing_area", "=", fishing_area])
+
+	water_bodies = frappe.get_all(
+		"Water Body",
+		filters=filters,
+		fields=[
+			"name as id",
+			"title",
+			"fishing_area",
+			"fishing_area_name",
+			"organization",
+			"organization_name",
+			"has_master_key_system",
+			"guest_passes_available",
+			"general_public_information",
+			"current_public_information",
+			"water_body_size as size",
+			"water_body_size_unit as size_unit",
+			"location",
+		],
+	)
+
+	for water_body in water_bodies:
+		water_body["fish_species"] = frappe.get_all(
+			"Fish Species Table",
+			filters={"parent": water_body["id"]},
+			pluck="fish_species",
+		)
+
+		water_body["special_provisions"] = frappe.get_all(
+			"Water Body Special Provision Table",
+			filters={"parent": water_body["id"]},
+			fields=["water_body_special_provision as id", "short_code"],
+		)
+
+		water_body["organizations"] = frappe.get_all(
+			"Water Body Management Local Organization",
+			filters={"water_body": water_body["id"]},
+			fields=["organization as id", "organization_name"],
+		)
+
+		if water_body.location:
+			water_body["geojson"] = frappe.parse_json(water_body.location)
+
+	return water_bodies

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021, Real Experts GmbH and contributors
 # For license information, please see license.txt
+from collections import defaultdict
 from typing import Dict, List
 
 import frappe
@@ -67,63 +68,143 @@ def remove_outdated_information():
 
 
 def build_water_body_cache(fishing_area: str = None):
-	"""Build the water body cache for all water bodies **OR** fishing area wise."""
+	"""
+	Build the water body cache for all water bodies **OR** fishing area wise.
+	"""
 	water_bodies = build_water_body_data(fishing_area=fishing_area)
-	frappe.cache().hset("water_body_data", fishing_area, water_bodies)
+	key = fishing_area or "all"
+	frappe.cache().hset("water_body_data", key, water_bodies)
 
 
 def build_water_body_data(id: str = None, fishing_area: str = None) -> List[Dict]:
-	"""Return a list of water bodies with fish species and special provisions."""
-	filters = [
-		["Water Body", "is_active", "=", 1],
-		["Water Body", "display_in_fishing_guide", "=", 1],
-	]
-	if id and isinstance(id, str):
-		filters.append(["Water Body", "name", "=", id])
+	"""
+	Return a list of water bodies with fish species and special provisions
+	"""
+	result = query_water_body_data(id=id, fishing_area=fishing_area)
+	return consolidate_water_body_data(water_body_data=result)
 
-	if fishing_area and isinstance(fishing_area, str):
-		filters.append(["Water Body", "fishing_area", "=", fishing_area])
 
-	water_bodies = frappe.get_all(
-		"Water Body",
-		filters=filters,
-		fields=[
-			"name as id",
-			"title",
-			"fishing_area",
-			"fishing_area_name",
-			"organization",
-			"organization_name",
-			"has_master_key_system",
-			"guest_passes_available",
-			"general_public_information",
-			"current_public_information",
-			"water_body_size as size",
-			"water_body_size_unit as size_unit",
-			"location",
-		],
+def query_water_body_data(id: str = None, fishing_area: str = None) -> List[Dict]:
+	water_body = frappe.qb.DocType("Water Body")
+	fish_species_table = frappe.qb.DocType("Fish Species Table")
+	wb_provision_table = frappe.qb.DocType("Water Body Special Provision Table")
+	wb_local_org_table = frappe.qb.DocType("Water Body Management Local Organization")
+
+	query = (
+		frappe.qb.from_(water_body)
+		.left_join(fish_species_table)
+		.on(fish_species_table.parent == water_body.name)
+		.left_join(wb_provision_table)
+		.on(wb_provision_table.parent == water_body.name)
+		.left_join(wb_local_org_table)
+		.on(wb_local_org_table.water_body == water_body.name)
+		.select(
+			water_body.name.as_("id"),
+			water_body.title,
+			water_body.fishing_area,
+			water_body.fishing_area_name,
+			water_body.organization,
+			water_body.organization_name,
+			water_body.has_master_key_system,
+			water_body.guest_passes_available,
+			water_body.general_public_information,
+			water_body.current_public_information,
+			water_body.water_body_size.as_("size"),
+			water_body.water_body_size_unit.as_("size_unit"),
+			water_body.location,
+			fish_species_table.fish_species,
+			wb_provision_table.water_body_special_provision,
+			wb_provision_table.short_code,
+			wb_local_org_table.organization.as_("local_organization"),
+			wb_local_org_table.organization_name.as_("local_organization_name"),
+		)
+		.where(water_body.is_active == 1)
+		.where(water_body.display_in_fishing_guide == 1)
 	)
 
-	for water_body in water_bodies:
-		water_body["fish_species"] = frappe.get_all(
-			"Fish Species Table",
-			filters={"parent": water_body["id"]},
-			pluck="fish_species",
+	if id and isinstance(id, str):
+		query = query.where(water_body.name == id)
+
+	if fishing_area and isinstance(fishing_area, str):
+		query = query.where(water_body.fishing_area == fishing_area)
+
+	return query.run(as_dict=True)
+
+
+def consolidate_water_body_data(water_body_data: List[Dict]) -> List[Dict]:
+	"""
+	Deduplicate the water body data such that each water body has a list of unique
+	fish species, special provisions and local organizations.
+	"""
+	water_body_map = {}  # {water_body_name: water_body_data}
+	fish_species_map, provision_map, local_org_map = (
+		defaultdict(list),
+		defaultdict(list),
+		defaultdict(list),
+	)
+
+	for entry in water_body_data:
+		water_body_name = entry.get("id")
+		if not water_body_name in water_body_map:
+			# Add entry to map if it does not exist
+			water_body_map[water_body_name] = init_row(water_body_row=entry)
+
+		result_entry = water_body_map[water_body_name]
+
+		# Add unique child table and Water Body Management Local Organization data
+		fish_species = entry.get("fish_species")
+		add_to_map(fish_species, "fish_species", entry, fish_species_map, result_entry)
+
+		provision = entry.get("water_body_special_provision")
+		add_to_map(provision, "special_provisions", entry, provision_map, result_entry)
+
+		org = entry.get("local_organization")
+		add_to_map(org, "organizations", entry, local_org_map, result_entry)
+
+	return [water_body_map.get(key) for key in water_body_map]
+
+
+def init_row(water_body_row: Dict) -> Dict:
+	# Prepare row to have Water Body data (excluding child tables)
+	water_body_copy = water_body_row.copy()
+
+	if water_body_copy.location:
+		water_body_copy["geojson"] = frappe.parse_json(water_body_copy.location)
+
+	for field in (
+		"fish_species",
+		"water_body_special_provision",
+		"short_code",
+		"local_organization",
+		"local_organization_name",
+	):
+		water_body_copy.pop(field)  # Remove child table fields
+
+	for field in ("fish_species", "special_provisions", "organizations"):
+		# Re-insert child table fields as lists
+		water_body_copy[field] = []
+
+	return water_body_copy
+
+
+def add_to_map(value, field, water_body, checking_map, result_map):
+	"""
+	Add the value to the `result_map` if it does not exist in the `checking_map`.
+	Also update the `checking_map` with the value.
+	"""
+	water_body_name = water_body.get("id")
+	checking_result_map = checking_map[water_body_name]
+
+	if not value or (value in checking_result_map):
+		return
+
+	checking_result_map.append(value)
+
+	if field == "fish_species":
+		result_map[field].append(value)
+	elif field == "special_provisions":
+		result_map[field].append({"id": value, "short_code": water_body.get("short_code")})
+	else:
+		result_map[field].append(
+			{"id": value, "organization_name": water_body.get("local_organization_name")}
 		)
-
-		water_body["special_provisions"] = frappe.get_all(
-			"Water Body Special Provision Table",
-			filters={"parent": water_body["id"]},
-			fields=["water_body_special_provision as id", "short_code"],
-		)
-
-		water_body["organizations"] = frappe.get_all(
-			"Water Body Management Local Organization",
-			filters={"water_body": water_body["id"]},
-			fields=["organization as id", "organization_name"],
-		)
-
-		if water_body.location:
-			water_body["geojson"] = frappe.parse_json(water_body.location)
-
-	return water_bodies

--- a/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.py
+++ b/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.py
@@ -5,6 +5,12 @@
 # import frappe
 from frappe.model.document import Document
 
+from landa.water_body_management.doctype.water_body.water_body import rebuild_water_body_cache
+
 
 class WaterBodyManagementLocalOrganization(Document):
-	pass
+	def on_update(self):
+		rebuild_water_body_cache(self.fishing_area)
+
+	def on_trash(self):
+		rebuild_water_body_cache(self.fishing_area)


### PR DESCRIPTION
> We do not need pagination right now as 900 water bodies is not a large payload

#### - Water Bodies are cached (all and fishing area wise)
#### - Cache Generation (900 Water Bodies with 2 Fish Species each) ⬇️
**Older Changes command**: 
```py
%prun -s cumulative water_body()
```

**Performance:**  (_5.957s_)
<img width="400" alt="Screenshot 2023-07-07 at 8 33 45 PM" src="https://github.com/alyf-de/landa/assets/25857446/4b86a1ae-00f0-4f52-9b28-f75d293d7d62">

**Newer Changes command**: 
```py
%prun -s cumulative build_water_body_cache()
```
**Performance:** (_0.142s_) **~98% faster ⚡️**
<img width="400" alt="Screenshot 2023-07-10 at 9 33 22 PM" src="https://github.com/alyf-de/landa/assets/25857446/086efa4d-cf87-42a3-bd67-2948a81ee95c">


**ToDo:**

- [x] Test cache generation with 800 odd water bodies
- [x] Patch to set Water body cache
- [ ] <s>Pagination (determine limit and sort by creation for predictable paginated results)</s>
- [x] If cache generation is very time consuming, <s>Enqueue and/or</s> optimise `build_water_body_data()` (Could be faster)