### PR TITLE
feat: cleanup obsolete address and contact flags (LAN-780)

### DIFF
--- a/landa/fixtures/translation.json
+++ b/landa/fixtures/translation.json
@@ -4519,13 +4519,13 @@
   "docstatus": 0,
   "doctype": "Translation",
   "language": "de",
-  "modified": "2021-12-03 17:22:26.449471",
+  "modified": "2023-09-26 15:40:26.449471",
   "name": "2418380635",
   "parent": null,
   "parentfield": null,
   "parenttype": null,
-  "source_text": "Primary Address (Full)",
-  "translated_text": "Prim\u00e4re Adresse (vollst\u00e4ndig)"
+  "source_text": "Full Address",
+  "translated_text": "Vollst\u00e4ndige Adresse"
  },
  {
   "context": null,
@@ -5806,22 +5806,6 @@
   "parenttype": null,
   "source_text": "Pincode",
   "translated_text": "Postleitzahl"
- },
- {
-  "context": null,
-  "contributed": 0,
-  "contribution_docname": null,
-  "contribution_status": "",
-  "docstatus": 0,
-  "doctype": "Translation",
-  "language": "de",
-  "modified": "2021-09-02 17:10:49.800353",
-  "name": "6dc383a8a1",
-  "parent": null,
-  "parentfield": null,
-  "parenttype": null,
-  "source_text": "Primary Address (Full)",
-  "translated_text": "Prim\u00e4re Adresse (kommagetrennt)"
  },
  {
   "context": null,

--- a/landa/organization_management/doctype/member_data_import/member_data_import.py
+++ b/landa/organization_management/doctype/member_data_import/member_data_import.py
@@ -173,8 +173,6 @@ def create_address(
 	address.pincode = pincode
 	address.city = city
 	address.country = "Germany"
-	address.is_primary_address = 1
-	address.is_shipping_address = 1
 	address.append("links", {"link_doctype": "LANDA Member", "link_name": member})
 	address.organization = organization
 

--- a/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
+++ b/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
@@ -106,10 +106,13 @@ def get_data(filters):
 	link_filters = get_link_filters(external_contact_ids)
 
 	# load addresses from db
+	address_filters = link_filters.copy()
+	address_filters.append(["disabled", "=", 0])
+
 	address_fields = ["address_line1", "pincode", "city"]
 	addresses = frappe.get_list(
 		"Address",
-		filters=link_filters,
+		filters=address_filters,
 		fields=[link_field] + address_fields,
 	)
 	# convert to pandas dataframe

--- a/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
+++ b/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
@@ -5,58 +5,59 @@ from typing import List
 
 import frappe
 import pandas as pd
+from frappe import _
 
 COLUMNS = [
 	{
 		"fieldname": "external_contact",
 		"fieldtype": "Link",
 		"options": "External Contact",
-		"label": "External Contact",
+		"label": _("External Contact"),
 	},
-	{"fieldname": "first_name", "fieldtype": "Data", "label": "First Name"},
-	{"fieldname": "last_name", "fieldtype": "Data", "label": "Last Name"},
+	{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+	{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
 	{
 		"fieldname": "organization",
 		"fieldtype": "Link",
 		"options": "Organization",
-		"label": "Organization",
+		"label": _("Organization"),
 	},
 	{
 		"fieldname": "is_magazine_recipient",
 		"fieldtype": "Check",
-		"label": "Is Magazine Recipient",
+		"label": _("Is Magazine Recipient"),
 	},
 	{
 		"fieldname": "external_functions",
 		"fieldtype": "Data",
-		"label": "External Functions",
+		"label": _("External Functions"),
 	},
 	{
 		"fieldname": "address_line1",
 		"fieldtype": "Data",
-		"label": "Address Line 1",
+		"label": _("Address Line 1"),
 	},
-	{"fieldname": "pincode", "fieldtype": "Data", "label": "Pincode"},
-	{"fieldname": "city", "fieldtype": "Data", "label": "City"},
+	{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+	{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
 	{
 		"fieldname": "full_address",
 		"fieldtype": "Data",
-		"label": "Full Address",
+		"label": _("Full Address"),
 	},
 	{
 		"fieldname": "primary_email_address",
 		"fieldtype": "Data",
-		"label": "Primary Email Address",
+		"label": _("Primary Email Address"),
 	},
 	{
 		"fieldname": "primary_phone",
 		"fieldtype": "Data",
-		"label": "Primary Phone",
+		"label": _("Primary Phone"),
 	},
 	{
 		"fieldname": "primary_mobile",
 		"fieldtype": "Data",
-		"label": "Primary Mobile",
+		"label": _("Primary Mobile"),
 	},
 ]
 

--- a/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
+++ b/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
@@ -41,7 +41,7 @@ COLUMNS = [
 	{
 		"fieldname": "full_address",
 		"fieldtype": "Data",
-		"label": "Primary Address (Full)",
+		"label": "Full Address",
 	},
 	{
 		"fieldname": "primary_email_address",
@@ -103,7 +103,7 @@ def get_data(filters):
 	link_filters = get_link_filters(external_contact_ids)
 
 	# load addresses from db
-	address_fields = ["address_line1", "pincode", "city", "is_primary_address"]
+	address_fields = ["address_line1", "pincode", "city"]
 	addresses = frappe.get_list(
 		"Address",
 		filters=link_filters,
@@ -111,16 +111,13 @@ def get_data(filters):
 	)
 	# convert to pandas dataframe
 	addresses_df = to_df(addresses, address_fields)
-	# remove all duplicate addresses by keeping only the primary address or last existing address if there is no primary address
-	addresses_df = remove_duplicate_indices(addresses_df, sort_by="is_primary_address")
+	# remove all duplicate addresses by keeping only the last existing address
+	addresses_df = remove_duplicate_indices(addresses_df)
 
 	# merge all columns to one address column and add this as the first column
 	addresses_df["full_address"] = (
 		addresses_df["address_line1"] + ", " + addresses_df["pincode"] + " " + addresses_df["city"]
 	)
-
-	# remove column 'is_primary_address'
-	addresses_df.drop("is_primary_address", axis=1, inplace=True)
 
 	# load contacts from db that are linked to the member fucntions loaded before
 	contact_fields = ["email_id", "phone", "mobile_no"]

--- a/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
+++ b/landa/organization_management/report/external_contacts_addresses_and_contacts/external_contacts_addresses_and_contacts.py
@@ -7,59 +7,61 @@ import frappe
 import pandas as pd
 from frappe import _
 
-COLUMNS = [
-	{
-		"fieldname": "external_contact",
-		"fieldtype": "Link",
-		"options": "External Contact",
-		"label": _("External Contact"),
-	},
-	{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
-	{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
-	{
-		"fieldname": "organization",
-		"fieldtype": "Link",
-		"options": "Organization",
-		"label": _("Organization"),
-	},
-	{
-		"fieldname": "is_magazine_recipient",
-		"fieldtype": "Check",
-		"label": _("Is Magazine Recipient"),
-	},
-	{
-		"fieldname": "external_functions",
-		"fieldtype": "Data",
-		"label": _("External Functions"),
-	},
-	{
-		"fieldname": "address_line1",
-		"fieldtype": "Data",
-		"label": _("Address Line 1"),
-	},
-	{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
-	{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
-	{
-		"fieldname": "full_address",
-		"fieldtype": "Data",
-		"label": _("Full Address"),
-	},
-	{
-		"fieldname": "primary_email_address",
-		"fieldtype": "Data",
-		"label": _("Primary Email Address"),
-	},
-	{
-		"fieldname": "primary_phone",
-		"fieldtype": "Data",
-		"label": _("Primary Phone"),
-	},
-	{
-		"fieldname": "primary_mobile",
-		"fieldtype": "Data",
-		"label": _("Primary Mobile"),
-	},
-]
+
+def get_columns():
+	return [
+		{
+			"fieldname": "external_contact",
+			"fieldtype": "Link",
+			"options": "External Contact",
+			"label": _("External Contact"),
+		},
+		{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+		{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
+		{
+			"fieldname": "organization",
+			"fieldtype": "Link",
+			"options": "Organization",
+			"label": _("Organization"),
+		},
+		{
+			"fieldname": "is_magazine_recipient",
+			"fieldtype": "Check",
+			"label": _("Is Magazine Recipient"),
+		},
+		{
+			"fieldname": "external_functions",
+			"fieldtype": "Data",
+			"label": _("External Functions"),
+		},
+		{
+			"fieldname": "address_line1",
+			"fieldtype": "Data",
+			"label": _("Address Line 1"),
+		},
+		{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+		{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
+		{
+			"fieldname": "full_address",
+			"fieldtype": "Data",
+			"label": _("Full Address"),
+		},
+		{
+			"fieldname": "primary_email_address",
+			"fieldtype": "Data",
+			"label": _("Primary Email Address"),
+		},
+		{
+			"fieldname": "primary_phone",
+			"fieldtype": "Data",
+			"label": _("Primary Phone"),
+		},
+		{
+			"fieldname": "primary_mobile",
+			"fieldtype": "Data",
+			"label": _("Primary Mobile"),
+		},
+	]
 
 
 def get_data(filters):
@@ -155,4 +157,4 @@ def get_data(filters):
 
 
 def execute(filters=None):
-	return COLUMNS, get_data(filters)
+	return get_columns(), get_data(filters)

--- a/landa/organization_management/report/magazine_address_list/magazine_address_list.py
+++ b/landa/organization_management/report/magazine_address_list/magazine_address_list.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import frappe
 import pandas as pd
+from frappe import _
 
 
 class Address:
@@ -139,52 +140,52 @@ class Address:
 				"fieldname": "landa_member",
 				"fieldtype": "Link",
 				"options": "LANDA Member",
-				"label": "Member",
+				"label": _("Member"),
 			},
-			{"fieldname": "first_name", "fieldtype": "Data", "label": "First Name"},
-			{"fieldname": "last_name", "fieldtype": "Data", "label": "Last Name"},
+			{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+			{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
 			{
 				"fieldname": "organization",
 				"fieldtype": "Link",
 				"options": "Organization",
-				"label": "Organization",
+				"label": _("Organization"),
 			},
 			{
 				"fieldname": "organization_name",
 				"fieldtype": "Data",
-				"label": "Organization Name",
+				"label": _("Organization Name"),
 			},
 			{
 				"fieldname": "magazine_recipient",
 				"fieldtype": "Check",
-				"label": "Is Magazine Recipient",
+				"label": _("Is Magazine Recipient"),
 			},
 			{
 				"fieldname": "year",
 				"fieldtype": "Int",
-				"label": "Year",
+				"label": _("Year"),
 			},
 			{
 				"fieldname": "permit_active",
 				"fieldtype": "Check",
-				"label": "Permit Is Active",
+				"label": _("Permit Is Active"),
 			},
 			{
 				"fieldname": "address_line1",
 				"fieldtype": "Data",
-				"label": "Address Line 1",
+				"label": _("Address Line 1"),
 			},
-			{"fieldname": "pincode", "fieldtype": "Data", "label": "Pincode"},
-			{"fieldname": "city", "fieldtype": "Data", "label": "City"},
+			{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+			{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
 			{
 				"fieldname": "full_address",
 				"fieldtype": "Data",
-				"label": "Full Address",
+				"label": _("Full Address"),
 			},
 			{
 				"fieldname": "magazine_active",
 				"fieldtype": "Check",
-				"label": "Magazine Is Active",
+				"label": _("Magazine Is Active"),
 			},
 		]
 

--- a/landa/organization_management/report/magazine_address_list/magazine_address_list.py
+++ b/landa/organization_management/report/magazine_address_list/magazine_address_list.py
@@ -77,13 +77,14 @@ class Address:
 
 		# define the labels of db entries that are supposed to be loaded
 		link_field_label = "`tabDynamic Link`.link_name as member"
-		link_filters = get_link_filters(members)
+		address_filters = get_link_filters(members)
+		address_filters.append(["disabled", "=", 0])
 
 		# load addresses from db
 		address_fields = ["address_line1", "pincode", "city"]
 		addresses = frappe.get_list(
 			"Address",
-			filters=link_filters,
+			filters=address_filters,
 			fields=address_fields + [link_field_label],
 			as_list=True,
 		)

--- a/landa/organization_management/report/magazine_address_list/magazine_address_list.py
+++ b/landa/organization_management/report/magazine_address_list/magazine_address_list.py
@@ -79,7 +79,7 @@ class Address:
 		link_filters = get_link_filters(members)
 
 		# load addresses from db
-		address_fields = ["address_line1", "pincode", "city", "is_primary_address"]
+		address_fields = ["address_line1", "pincode", "city"]
 		addresses = frappe.get_list(
 			"Address",
 			filters=link_filters,
@@ -88,16 +88,13 @@ class Address:
 		)
 		# convert to pandas dataframe
 		addresses_df = frappe_tuple_to_pandas_df(addresses, address_fields + ["member"])
-		# remove all duplicate addresses by keeping only the primary address or last existing address if there is no primary address
-		addresses_df = remove_duplicate_indices(addresses_df, sort_by="is_primary_address")
+		# remove all duplicate addresses by keeping only the last existing address
+		addresses_df = remove_duplicate_indices(addresses_df)
 
 		# merge all columns to one address column and add this as the first column
 		addresses_df["full_address"] = (
 			addresses_df["address_line1"] + ", " + addresses_df["pincode"] + " " + addresses_df["city"]
 		)
-
-		# remove column 'is_primary_address'
-		addresses_df.drop("is_primary_address", axis=1, inplace=True)
 
 		# load addresses from db
 		permit_fields = ["year", "member", "docstatus"]
@@ -182,7 +179,7 @@ class Address:
 			{
 				"fieldname": "full_address",
 				"fieldtype": "Data",
-				"label": "Primary Address (Full)",
+				"label": "Full Address",
 			},
 			{
 				"fieldname": "magazine_active",

--- a/landa/organization_management/report/magazine_address_list/magazine_address_list.py
+++ b/landa/organization_management/report/magazine_address_list/magazine_address_list.py
@@ -112,8 +112,9 @@ class Address:
 		permits_df.drop("docstatus", axis=1, inplace=True)
 		permits_df = remove_duplicate_indices(permits_df, sort_by="year")
 
-		this_year = int(datetime.today().strftime("%Y"))
-		this_month = int(datetime.today().strftime("%m"))
+		now = datetime.now()
+		this_year = now.year
+		this_month = now.month
 		# if this month is January to June: members need a permit for this year or last year:
 		if this_month < 7:
 			permits_df["permit_active"] = [

--- a/landa/organization_management/report/member_address_list/member_address_list.json
+++ b/landa/organization_management/report/member_address_list/member_address_list.json
@@ -41,7 +41,7 @@
   {
    "fieldname": "full_address",
    "fieldtype": "Data",
-   "label": "Primary Address (Full)",
+   "label": "Full Address",
    "width": 0
   }
  ],

--- a/landa/organization_management/report/member_address_list/member_address_list.py
+++ b/landa/organization_management/report/member_address_list/member_address_list.py
@@ -19,7 +19,7 @@ class Address(Member):
 		link_filters = get_link_filters(self.members)
 
 		# load addresses from db
-		address_fields = ["address_line1", "pincode", "city", "is_primary_address"]
+		address_fields = ["address_line1", "pincode", "city"]
 		addresses = frappe.get_list(
 			"Address",
 			filters=link_filters,
@@ -30,16 +30,13 @@ class Address(Member):
 		addresses_df = pd.DataFrame(addresses, columns=address_fields + ["member"])
 		addresses_df.set_index("member", inplace=True)
 
-		# remove all duplicate addresses by keeping only the primary address or last existing address if there is no primary address
-		addresses_df = remove_duplicate_indices(addresses_df, sort_by="is_primary_address")
+		# remove all duplicate addresses by keeping only the last existing address
+		addresses_df = remove_duplicate_indices(addresses_df)
 
 		# merge all columns to one address column and add this as the first column
 		addresses_df["full_address"] = (
 			addresses_df["address_line1"] + ", " + addresses_df["pincode"] + " " + addresses_df["city"]
 		)
-
-		# remove column 'is_primary_address'
-		addresses_df.drop("is_primary_address", axis=1, inplace=True)
 
 		# merge all dataframes from different doctypes
 		data = pd.concat([self.members_df, addresses_df], axis=1).reindex(self.members_df.index)
@@ -83,7 +80,7 @@ class Address(Member):
 			{
 				"fieldname": "full_address",
 				"fieldtype": "Data",
-				"label": "Primary Address (Full)",
+				"label": "Full Address",
 			},
 		]
 

--- a/landa/organization_management/report/member_address_list/member_address_list.py
+++ b/landa/organization_management/report/member_address_list/member_address_list.py
@@ -17,13 +17,14 @@ class Address(Member):
 
 		# define the labels of db entries that are supposed to be loaded
 		link_field_label = "`tabDynamic Link`.link_name as member"
-		link_filters = get_link_filters(self.members)
+		address_filters = get_link_filters(self.members)
+		address_filters.append(["disabled", "=", 0])
 
 		# load addresses from db
 		address_fields = ["address_line1", "pincode", "city"]
 		addresses = frappe.get_list(
 			"Address",
-			filters=link_filters,
+			filters=address_filters,
 			fields=address_fields + [link_field_label],
 			as_list=True,
 		)

--- a/landa/organization_management/report/member_address_list/member_address_list.py
+++ b/landa/organization_management/report/member_address_list/member_address_list.py
@@ -3,6 +3,7 @@
 
 import frappe
 import pandas as pd
+from frappe import _
 
 from ..member.member import Member, get_link_filters, remove_duplicate_indices
 
@@ -55,32 +56,32 @@ class Address(Member):
 				"fieldname": "landa_member",
 				"fieldtype": "Link",
 				"options": "LANDA Member",
-				"label": "Member",
+				"label": _("Member"),
 			},
-			{"fieldname": "first_name", "fieldtype": "Data", "label": "First Name"},
-			{"fieldname": "last_name", "fieldtype": "Data", "label": "Last Name"},
+			{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+			{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
 			{
 				"fieldname": "organization",
 				"fieldtype": "Link",
 				"options": "Organization",
-				"label": "Organization",
+				"label": _("Organization"),
 			},
 			{
 				"fieldname": "organization_name",
 				"fieldtype": "Data",
-				"label": "Organization Name",
+				"label": _("Organization Name"),
 			},
 			{
 				"fieldname": "address_line1",
 				"fieldtype": "Data",
-				"label": "Address Line 1",
+				"label": _("Address Line 1"),
 			},
-			{"fieldname": "pincode", "fieldtype": "Data", "label": "Pincode"},
-			{"fieldname": "city", "fieldtype": "Data", "label": "City"},
+			{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+			{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
 			{
 				"fieldname": "full_address",
 				"fieldtype": "Data",
-				"label": "Full Address",
+				"label": _("Full Address"),
 			},
 		]
 

--- a/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
+++ b/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
@@ -3,6 +3,7 @@
 
 import frappe
 import pandas as pd
+from frappe import _
 
 from landa.organization_management.birthday import (
 	get_age,
@@ -15,69 +16,69 @@ COLUMNS = [
 		"fieldname": "landa_member",
 		"fieldtype": "Link",
 		"options": "LANDA Member",
-		"label": "Member",
+		"label": _("Member"),
 	},
-	{"fieldname": "first_name", "fieldtype": "Data", "label": "First Name"},
-	{"fieldname": "last_name", "fieldtype": "Data", "label": "Last Name"},
+	{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+	{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
 	{
 		"fieldname": "organization",
 		"fieldtype": "Link",
 		"options": "Organization",
-		"label": "Organization",
+		"label": _("Organization"),
 	},
 	{
 		"fieldname": "organization_name",
 		"fieldtype": "Data",
-		"label": "Organization Name",
+		"label": _("Organization Name"),
 	},
 	{
 		"fieldname": "member_function_category",
 		"fieldtype": "Data",
-		"label": "Member Function Categories",
+		"label": _("Member Function Categories"),
 	},
 	{
 		"fieldname": "primary_email_address",
 		"fieldtype": "Data",
-		"label": "Primary Email Address",
+		"label": _("Primary Email Address"),
 	},
 	{
 		"fieldname": "primary_phone",
 		"fieldtype": "Data",
-		"label": "Primary Phone",
+		"label": _("Primary Phone"),
 	},
 	{
 		"fieldname": "primary_mobile",
 		"fieldtype": "Data",
-		"label": "Primary Mobile",
+		"label": _("Primary Mobile"),
 	},
 	{
 		"fieldname": "full_address",
 		"fieldtype": "Data",
-		"label": "Full Address",
+		"label": _("Full Address"),
 	},
 	{
 		"fieldname": "address_line1",
 		"fieldtype": "Data",
-		"label": "Address Line 1",
+		"label": _("Address Line 1"),
 	},
-	{"fieldname": "pincode", "fieldtype": "Data", "label": "Pincode"},
-	{"fieldname": "city", "fieldtype": "Data", "label": "City"},
-	{"fieldname": "award_list", "fieldtype": "Data", "label": "Award List"},
+	{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+	{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
+	{"fieldname": "award_list", "fieldtype": "Data", "label": _("Award List")},
 	{
 		"fieldname": "date_of_birth",
 		"fieldtype": "Date",
-		"label": "Date of Birth",
+		"label": _("Date of Birth"),
 	},
-	{"fieldname": "member_age", "fieldtype": "Data", "label": "Age"},
+	{"fieldname": "member_age", "fieldtype": "Data", "label": _("Age")},
 	{
 		"fieldname": "upcoming_birthday",
 		"fieldtype": "Date",
-		"label": "Upcoming Birthday",
+		"label": _("Upcoming Birthday"),
 	},
 	{
 		"fieldname": "is_decadal_birthday",
 		"fieldtype": "Check",
-		"label": "Is Decadal Birthday",
+		"label": _("Is Decadal Birthday"),
 	},
 ]
 

--- a/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
+++ b/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
@@ -179,21 +179,13 @@ def get_data(filters):
 	awards_df = aggregate_entries(awards_df, aggregate_field="award_list", sort_by=["issue_date"])
 	awards_df.drop(award_fields[:-1], axis=1, inplace=True)
 
-	# load addresses from db
 	address_fields = ["address_line1", "pincode", "city"]
 	addresses = get_contact_details("Address", MEMBERS, address_fields)
-
-	# convert to pandas dataframe
 	addresses_df = frappe_tuple_to_pandas_df(addresses, address_fields + ["member"])
-	# remove all duplicate addresses by keeping only the last existing address
 	addresses_df = remove_duplicate_indices(addresses_df)
-
-	# merge all columns to one address column and add this as the first column
 	addresses_df["full_address"] = (
 		addresses_df["address_line1"] + ", " + addresses_df["pincode"] + " " + addresses_df["city"]
 	)
-	address_cols = addresses_df.columns.tolist()
-	addresses_df = addresses_df[address_cols[-1:] + address_cols[:-1]]
 
 	# load contacts from db that are linked to the member fucntions loaded before
 	contact_fields = ["email_id", "phone", "mobile_no"]

--- a/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
+++ b/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
@@ -11,76 +11,78 @@ from landa.organization_management.birthday import (
 	next_birthday_is_decadal,
 )
 
-COLUMNS = [
-	{
-		"fieldname": "landa_member",
-		"fieldtype": "Link",
-		"options": "LANDA Member",
-		"label": _("Member"),
-	},
-	{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
-	{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
-	{
-		"fieldname": "organization",
-		"fieldtype": "Link",
-		"options": "Organization",
-		"label": _("Organization"),
-	},
-	{
-		"fieldname": "organization_name",
-		"fieldtype": "Data",
-		"label": _("Organization Name"),
-	},
-	{
-		"fieldname": "member_function_category",
-		"fieldtype": "Data",
-		"label": _("Member Function Categories"),
-	},
-	{
-		"fieldname": "primary_email_address",
-		"fieldtype": "Data",
-		"label": _("Primary Email Address"),
-	},
-	{
-		"fieldname": "primary_phone",
-		"fieldtype": "Data",
-		"label": _("Primary Phone"),
-	},
-	{
-		"fieldname": "primary_mobile",
-		"fieldtype": "Data",
-		"label": _("Primary Mobile"),
-	},
-	{
-		"fieldname": "full_address",
-		"fieldtype": "Data",
-		"label": _("Full Address"),
-	},
-	{
-		"fieldname": "address_line1",
-		"fieldtype": "Data",
-		"label": _("Address Line 1"),
-	},
-	{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
-	{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
-	{"fieldname": "award_list", "fieldtype": "Data", "label": _("Award List")},
-	{
-		"fieldname": "date_of_birth",
-		"fieldtype": "Date",
-		"label": _("Date of Birth"),
-	},
-	{"fieldname": "member_age", "fieldtype": "Data", "label": _("Age")},
-	{
-		"fieldname": "upcoming_birthday",
-		"fieldtype": "Date",
-		"label": _("Upcoming Birthday"),
-	},
-	{
-		"fieldname": "is_decadal_birthday",
-		"fieldtype": "Check",
-		"label": _("Is Decadal Birthday"),
-	},
-]
+
+def get_columns():
+	return [
+		{
+			"fieldname": "landa_member",
+			"fieldtype": "Link",
+			"options": "LANDA Member",
+			"label": _("Member"),
+		},
+		{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+		{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
+		{
+			"fieldname": "organization",
+			"fieldtype": "Link",
+			"options": "Organization",
+			"label": _("Organization"),
+		},
+		{
+			"fieldname": "organization_name",
+			"fieldtype": "Data",
+			"label": _("Organization Name"),
+		},
+		{
+			"fieldname": "member_function_category",
+			"fieldtype": "Data",
+			"label": _("Member Function Categories"),
+		},
+		{
+			"fieldname": "primary_email_address",
+			"fieldtype": "Data",
+			"label": _("Primary Email Address"),
+		},
+		{
+			"fieldname": "primary_phone",
+			"fieldtype": "Data",
+			"label": _("Primary Phone"),
+		},
+		{
+			"fieldname": "primary_mobile",
+			"fieldtype": "Data",
+			"label": _("Primary Mobile"),
+		},
+		{
+			"fieldname": "full_address",
+			"fieldtype": "Data",
+			"label": _("Full Address"),
+		},
+		{
+			"fieldname": "address_line1",
+			"fieldtype": "Data",
+			"label": _("Address Line 1"),
+		},
+		{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+		{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
+		{"fieldname": "award_list", "fieldtype": "Data", "label": _("Award List")},
+		{
+			"fieldname": "date_of_birth",
+			"fieldtype": "Date",
+			"label": _("Date of Birth"),
+		},
+		{"fieldname": "member_age", "fieldtype": "Data", "label": _("Age")},
+		{
+			"fieldname": "upcoming_birthday",
+			"fieldtype": "Date",
+			"label": _("Upcoming Birthday"),
+		},
+		{
+			"fieldname": "is_decadal_birthday",
+			"fieldtype": "Check",
+			"label": _("Is Decadal Birthday"),
+		},
+	]
 
 
 def get_data(filters):
@@ -239,4 +241,4 @@ def get_data(filters):
 
 
 def execute(filters):
-	return COLUMNS, get_data(filters)
+	return get_columns(), get_data(filters)

--- a/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
+++ b/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
@@ -65,7 +65,7 @@ def get_columns():
 		},
 		{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
 		{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
-		{"fieldname": "award_list", "fieldtype": "Data", "label": _("Award List")},
+		{"fieldname": "awards", "fieldtype": "Data", "label": _("Awards")},
 		{
 			"fieldname": "date_of_birth",
 			"fieldtype": "Date",
@@ -172,11 +172,11 @@ def get_data(filters):
 	)
 
 	awards_df = pd.DataFrame.from_records(awards, columns=award_fields, index="member")
-	awards_df["award_list"] = [
+	awards_df["awards"] = [
 		at + " " + str(ad.year)
 		for at, ad in zip(awards_df["award_type"].values, awards_df["issue_date"].values)
 	]
-	awards_df = aggregate_entries(awards_df, aggregate_field="award_list", sort_by=["issue_date"])
+	awards_df = aggregate_entries(awards_df, aggregate_field="awards", sort_by=["issue_date"])
 	awards_df.drop(award_fields[:-1], axis=1, inplace=True)
 
 	address_fields = ["address_line1", "pincode", "city"]
@@ -215,7 +215,7 @@ def get_data(filters):
 			"address_line1",
 			"pincode",
 			"city",
-			"award_list",
+			"awards",
 			"date_of_birth",
 			"age",
 			"upcoming_birthday",

--- a/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
+++ b/landa/organization_management/report/members_with_member_functions/members_with_member_functions.py
@@ -53,7 +53,7 @@ COLUMNS = [
 	{
 		"fieldname": "full_address",
 		"fieldtype": "Data",
-		"label": "Primary Address (Full)",
+		"label": "Full Address",
 	},
 	{
 		"fieldname": "address_line1",
@@ -177,13 +177,13 @@ def get_data(filters):
 	awards_df.drop(award_fields[:-1], axis=1, inplace=True)
 
 	# load addresses from db
-	address_fields = ["address_line1", "pincode", "city", "is_primary_address"]
+	address_fields = ["address_line1", "pincode", "city"]
 	addresses = get_contact_details("Address", MEMBERS, address_fields)
 
 	# convert to pandas dataframe
 	addresses_df = frappe_tuple_to_pandas_df(addresses, address_fields + ["member"])
-	# remove all duplicate addresses by keeping only the primary address or last existing address if there is no primary address
-	addresses_df = remove_duplicate_indices(addresses_df, sort_by="is_primary_address")
+	# remove all duplicate addresses by keeping only the last existing address
+	addresses_df = remove_duplicate_indices(addresses_df)
 
 	# merge all columns to one address column and add this as the first column
 	addresses_df["full_address"] = (
@@ -191,8 +191,6 @@ def get_data(filters):
 	)
 	address_cols = addresses_df.columns.tolist()
 	addresses_df = addresses_df[address_cols[-1:] + address_cols[:-1]]
-	# remove column 'is_primary_address'
-	addresses_df.drop("is_primary_address", axis=1, inplace=True)
 
 	# load contacts from db that are linked to the member fucntions loaded before
 	contact_fields = ["email_id", "phone", "mobile_no"]

--- a/landa/patches.txt
+++ b/landa/patches.txt
@@ -25,3 +25,4 @@ landa.patches.update_system_settings
 landa.patches.delete_customized_workspaces  # 2023-08-14
 landa.patches.build_water_body_cache  # 2023-08-14
 landa.patches.set_hide_custom_in_user_workspaces
+landa.patches.cleanup_addresses_and_contacts

--- a/landa/patches/cleanup_addresses_and_contacts.py
+++ b/landa/patches/cleanup_addresses_and_contacts.py
@@ -8,13 +8,11 @@ def execute():
 
 def cleanup_addresses():
 	# the two checkboxes are no longer used and are hidden from now on.
-	frappe.db.sql(
-		"""update `tabAddress` set is_shipping_address=0, is_primary_address=0"""
-	)  # nosemgrep
+	# nosemgrep
+	frappe.db.sql("""update `tabAddress` set is_shipping_address=0, is_primary_address=0""")
 
 
 def cleanup_contacts():
 	# the two checkboxes are no longer used and are hidden from now on.
-	frappe.db.sql(
-		"""update `tabContact` set is_billing_contact=0, is_primary_contact=0"""
-	)  # nosemgrep
+	# nosemgrep
+	frappe.db.sql("""update `tabContact` set is_billing_contact=0, is_primary_contact=0""")

--- a/landa/patches/cleanup_addresses_and_contacts.py
+++ b/landa/patches/cleanup_addresses_and_contacts.py
@@ -8,9 +8,13 @@ def execute():
 
 def cleanup_addresses():
 	# the two checkboxes are no longer used and are hidden from now on.
-	frappe.db.sql("""update `tabAddress` set is_shipping_address=0, is_primary_address=0""")
+	frappe.db.sql(
+		"""update `tabAddress` set is_shipping_address=0, is_primary_address=0"""
+	)  # nosemgrep
 
 
 def cleanup_contacts():
 	# the two checkboxes are no longer used and are hidden from now on.
-	frappe.db.sql("""update `tabContact` set is_billing_contact=0, is_primary_contact=0""")
+	frappe.db.sql(
+		"""update `tabContact` set is_billing_contact=0, is_primary_contact=0"""
+	)  # nosemgrep

--- a/landa/patches/cleanup_addresses_and_contacts.py
+++ b/landa/patches/cleanup_addresses_and_contacts.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+	cleanup_addresses()
+	cleanup_contacts()
+
+
+def cleanup_addresses():
+	# the two checkboxes are no longer used and are hidden from now on.
+	frappe.db.sql("""update `tabAddress` set is_shipping_address=0, is_primary_address=0""")
+
+
+def cleanup_contacts():
+	# the two checkboxes are no longer used and are hidden from now on.
+	frappe.db.sql("""update `tabContact` set is_billing_contact=0, is_primary_contact=0""")

--- a/landa/patches/set_billing_and_shipping_defaults.py
+++ b/landa/patches/set_billing_and_shipping_defaults.py
@@ -8,10 +8,6 @@ from frappe.query_builder import DocType
 
 def execute():
 	set_billing_and_shipping_defaults()
-	# Cleanup of data not yet now, but in the next release. Ask Samuel why.
-	# TODO: Clean data
-	# cleanup_addresses()
-	# cleanup_contacts()
 
 
 def customize_customer():
@@ -75,13 +71,3 @@ def set_billing_and_shipping_defaults():
 					"default_shipping_address": address_name,
 				},
 			)
-
-
-def cleanup_addresses():
-	# the two checkboxes are no longer used and are hidden from now on.
-	frappe.db.sql("""update `tabAddress` set is_shipping_address=0, is_primary_address=0""")
-
-
-def cleanup_contacts():
-	# the two checkboxes are no longer used and are hidden from now on.
-	frappe.db.sql("""update `tabContact` set is_billing_contact=0, is_primary_contact=0""")

--- a/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
+++ b/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
@@ -118,6 +118,10 @@ def get_data(filters=None):
 		],
 	)
 
+	# Drop rows with empty index (member) column. Otherwise they could not be
+	# concatenated with the other dataframes later.
+	wbm_df = wbm_df[wbm_df.index.notnull()]
+
 	# define the labels of db entries that are supposed to be loaded
 	link_field_label = "`tabDynamic Link`.link_name as member"
 	link_filters = get_link_filters(wbm)

--- a/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
+++ b/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
@@ -147,13 +147,9 @@ def get_data(filters=None):
 	)
 	# remove all duplicate addresses by keeping only the last existing address
 	addresses_df = remove_duplicate_indices(addresses_df)
-
-	# merge all columns to one address column and add this as the first column
 	addresses_df["full_address"] = (
 		addresses_df["address_line1"] + ", " + addresses_df["pincode"] + " " + addresses_df["city"]
 	)
-	address_cols = addresses_df.columns.tolist()
-	addresses_df = addresses_df[address_cols[-1:] + address_cols[:-1]]
 
 	# load contacts from db that are linked to the member fucntions loaded before
 	contacts = frappe.get_all(

--- a/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
+++ b/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
@@ -123,9 +123,11 @@ def get_data(filters=None):
 	link_filters = get_link_filters(wbm)
 
 	# load addresses from db
+	address_filters = link_filters.copy()
+	address_filters.append(["disabled", "=", 0])
 	addresses = frappe.get_all(
 		"Address",
-		filters=link_filters,
+		filters=address_filters,
 		fields=[
 			"address_line1",
 			"pincode",

--- a/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
+++ b/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
@@ -7,65 +7,67 @@ from frappe import _
 
 from landa.utils import get_current_member_data
 
-COLUMNS = [
-	{
-		"fieldname": "landa_member",
-		"fieldtype": "Link",
-		"options": "LANDA Member",
-		"label": _("Member"),
-	},
-	{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
-	{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
-	{
-		"fieldname": "organization",
-		"fieldtype": "Link",
-		"options": "Organization",
-		"label": _("Organization"),
-	},
-	{
-		"fieldname": "organization_name",
-		"fieldtype": "Data",
-		"label": _("Organization Name"),
-	},
-	{
-		"fieldname": "water_body",
-		"fieldtype": "Link",
-		"label": _("Water Body"),
-		"options": "Water Body",
-	},
-	{
-		"fieldname": "water_body_title",
-		"fieldtype": "Data",
-		"label": _("Water Body Title"),
-	},
-	{
-		"fieldname": "primary_email_address",
-		"fieldtype": "Data",
-		"label": _("Primary Email Address"),
-	},
-	{
-		"fieldname": "primary_phone",
-		"fieldtype": "Data",
-		"label": _("Primary Phone"),
-	},
-	{
-		"fieldname": "primary_mobile",
-		"fieldtype": "Data",
-		"label": _("Primary Mobile"),
-	},
-	{
-		"fieldname": "full_address",
-		"fieldtype": "Data",
-		"label": _("Full Address"),
-	},
-	{
-		"fieldname": "address_line1",
-		"fieldtype": "Data",
-		"label": _("Address Line 1"),
-	},
-	{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
-	{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
-]
+
+def get_columns():
+	return [
+		{
+			"fieldname": "landa_member",
+			"fieldtype": "Link",
+			"options": "LANDA Member",
+			"label": _("Member"),
+		},
+		{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+		{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
+		{
+			"fieldname": "organization",
+			"fieldtype": "Link",
+			"options": "Organization",
+			"label": _("Organization"),
+		},
+		{
+			"fieldname": "organization_name",
+			"fieldtype": "Data",
+			"label": _("Organization Name"),
+		},
+		{
+			"fieldname": "water_body",
+			"fieldtype": "Link",
+			"label": _("Water Body"),
+			"options": "Water Body",
+		},
+		{
+			"fieldname": "water_body_title",
+			"fieldtype": "Data",
+			"label": _("Water Body Title"),
+		},
+		{
+			"fieldname": "primary_email_address",
+			"fieldtype": "Data",
+			"label": _("Primary Email Address"),
+		},
+		{
+			"fieldname": "primary_phone",
+			"fieldtype": "Data",
+			"label": _("Primary Phone"),
+		},
+		{
+			"fieldname": "primary_mobile",
+			"fieldtype": "Data",
+			"label": _("Primary Mobile"),
+		},
+		{
+			"fieldname": "full_address",
+			"fieldtype": "Data",
+			"label": _("Full Address"),
+		},
+		{
+			"fieldname": "address_line1",
+			"fieldtype": "Data",
+			"label": _("Address Line 1"),
+		},
+		{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+		{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
+	]
 
 
 def get_data(filters=None):
@@ -193,4 +195,4 @@ def execute(filters=None):
 	if regional_organization:
 		filters["regional_organization"] = regional_organization
 
-	return COLUMNS, get_data(filters)
+	return get_columns(), get_data(filters)

--- a/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
+++ b/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
@@ -3,6 +3,7 @@
 
 import frappe
 import pandas as pd
+from frappe import _
 
 from landa.utils import get_current_member_data
 
@@ -11,59 +12,59 @@ COLUMNS = [
 		"fieldname": "landa_member",
 		"fieldtype": "Link",
 		"options": "LANDA Member",
-		"label": "Member",
+		"label": _("Member"),
 	},
-	{"fieldname": "first_name", "fieldtype": "Data", "label": "First Name"},
-	{"fieldname": "last_name", "fieldtype": "Data", "label": "Last Name"},
+	{"fieldname": "first_name", "fieldtype": "Data", "label": _("First Name")},
+	{"fieldname": "last_name", "fieldtype": "Data", "label": _("Last Name")},
 	{
 		"fieldname": "organization",
 		"fieldtype": "Link",
 		"options": "Organization",
-		"label": "Organization",
+		"label": _("Organization"),
 	},
 	{
 		"fieldname": "organization_name",
 		"fieldtype": "Data",
-		"label": "Organization Name",
+		"label": _("Organization Name"),
 	},
 	{
 		"fieldname": "water_body",
 		"fieldtype": "Link",
-		"label": "Water Body",
+		"label": _("Water Body"),
 		"options": "Water Body",
 	},
 	{
 		"fieldname": "water_body_title",
 		"fieldtype": "Data",
-		"label": "Water Body Title",
+		"label": _("Water Body Title"),
 	},
 	{
 		"fieldname": "primary_email_address",
 		"fieldtype": "Data",
-		"label": "Primary Email Address",
+		"label": _("Primary Email Address"),
 	},
 	{
 		"fieldname": "primary_phone",
 		"fieldtype": "Data",
-		"label": "Primary Phone",
+		"label": _("Primary Phone"),
 	},
 	{
 		"fieldname": "primary_mobile",
 		"fieldtype": "Data",
-		"label": "Primary Mobile",
+		"label": _("Primary Mobile"),
 	},
 	{
 		"fieldname": "full_address",
 		"fieldtype": "Data",
-		"label": "Full Address",
+		"label": _("Full Address"),
 	},
 	{
 		"fieldname": "address_line1",
 		"fieldtype": "Data",
-		"label": "Address Line 1",
+		"label": _("Address Line 1"),
 	},
-	{"fieldname": "pincode", "fieldtype": "Data", "label": "Pincode"},
-	{"fieldname": "city", "fieldtype": "Data", "label": "City"},
+	{"fieldname": "pincode", "fieldtype": "Data", "label": _("Pincode")},
+	{"fieldname": "city", "fieldtype": "Data", "label": _("City")},
 ]
 
 

--- a/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
+++ b/landa/water_body_management/report/members_in_water_body_management/members_in_water_body_management.py
@@ -55,7 +55,7 @@ COLUMNS = [
 	{
 		"fieldname": "full_address",
 		"fieldtype": "Data",
-		"label": "Primary Address (Full)",
+		"label": "Full Address",
 	},
 	{
 		"fieldname": "address_line1",
@@ -127,7 +127,6 @@ def get_data(filters=None):
 			"address_line1",
 			"pincode",
 			"city",
-			"is_primary_address",
 			link_field_label,
 		],
 	)
@@ -135,10 +134,10 @@ def get_data(filters=None):
 	addresses_df = pd.DataFrame.from_records(
 		addresses,
 		index="member",
-		columns=["address_line1", "pincode", "city", "is_primary_address", "member"],
+		columns=["address_line1", "pincode", "city", "member"],
 	)
-	# remove all duplicate addresses by keeping only the primary address or last existing address if there is no primary address
-	addresses_df = remove_duplicate_indices(addresses_df, sort_by="is_primary_address")
+	# remove all duplicate addresses by keeping only the last existing address
+	addresses_df = remove_duplicate_indices(addresses_df)
 
 	# merge all columns to one address column and add this as the first column
 	addresses_df["full_address"] = (
@@ -146,8 +145,6 @@ def get_data(filters=None):
 	)
 	address_cols = addresses_df.columns.tolist()
 	addresses_df = addresses_df[address_cols[-1:] + address_cols[:-1]]
-	# remove column 'is_primary_address'
-	addresses_df.drop("is_primary_address", axis=1, inplace=True)
 
 	# load contacts from db that are linked to the member fucntions loaded before
 	contacts = frappe.get_all(


### PR DESCRIPTION
Only various LANDA member reports are affected by this. If there are multiple addresses for a LANDA member, https://github.com/alyf-de/landa/blob/3f2e14161390248e0c18a5eebc1ddcaf52eb5d82/landa/organization_management/report/member/member.py#L43-L49 is used to determine which one is displayed.

There is currently no possibility to explicitly display an address preferentially.