### PR TITLE
fix: Add change log ID and avoid None as string from query (LAN-781)

### DIFF
--- a/landa/water_body_management/utils.py
+++ b/landa/water_body_management/utils.py
@@ -55,6 +55,7 @@ def get_formatted_changes(changes_list: List):
 		if event in ["Created", "Deleted"]:
 			changes.append(
 				{
+					"id": entry.name,
 					"doctype": entry.doctype,
 					"docname": entry.docname,
 					"event": event,
@@ -116,8 +117,8 @@ def get_deleted_document_query(from_datetime: str):
 			deleted_document.creation,
 			deleted_document.data,
 			ConstantColumn(1).as_("deleted"),
-			ConstantColumn(None).as_("attached_to_doctype"),
-			ConstantColumn(None).as_("attached_to_name"),
+			ConstantColumn("").as_("attached_to_doctype"),
+			ConstantColumn("").as_("attached_to_name"),
 		)
 		.where(
 			deleted_document.creation >= from_datetime,
@@ -146,6 +147,7 @@ def get_event(entry, changed_data):
 def build_modified_change_log(entry, changed_data, event):
 	"""Return a pretty dict with changes for modified Water Body/Fish Species."""
 	change_log = {
+		"id": entry.name,
 		"doctype": entry.doctype,
 		"docname": entry.docname,
 		"datetime": entry.creation,
@@ -191,6 +193,7 @@ def build_dependency_change_log(entry, changed_data):
 
 	key = "files" if entry.doctype == "File" else "organizations"
 	return {
+		"id": entry.name,
 		"doctype": "Water Body",
 		"docname": ref_water_body,
 		"event": "Modified",


### PR DESCRIPTION
- Added 'id' as one of he return values in change log API. ID = Version/Deleted Document name
- Query must return empty string for non existent columns. During string OR comparison, "None" takes precedence and is truthy

**Response:**
```js
[
	{
		"id":"d55382bc40",   // New
		"doctype":"Water Body",
		"docname":"L12-2345",
		"event":"Deleted",
		"datetime":"2023-09-26 11:08:07.858777"
	},
	{
		"id":"05a98bcf9c",   // New
		"doctype":"Water Body",
		"docname":"D11-12345",
		"event":"Modified",
		"datetime":"2023-09-26 13:25:26.728430",
		"changes":{"files":null}
	}
]
```

**Misc fix:**
- ConstantColumn must return empty string. "None" was causing false truthy values which broke string comparisons (e.g. "None" or "L10" = "None")
