### PR TITLE
fix(Water Body): clear cache only once, after updating all water bodies

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,10 +57,9 @@ Get a list of water bodies along with their main fish species and special provis
     Parameters:
 
     - `id` (optional): return only data of the water body with this ID.
-    - `fishing_area` (optional): return only water bodies in this fishing_area.
     - `only_id` (optional, 1 or 0, default: 0): return only the IDs of the water bodies.
 
-The parameters `only_id` and `fishing_area` can be combined. The other parameters are mutually exclusive.
+The parameters are mutually exclusive.
 
 ### Example Requests
 
@@ -76,12 +75,6 @@ Get a specific water body:
 
 ```bash
 curl --location "$BASE_URL/api/method/landa.api.water_body?id=C09-110"
-```
-
-Get all water bodies in a specific fishing area:
-
-```bash
-curl --location "$BASE_URL/api/method/landa.api.water_body?fishing_area=C09"
 ```
 
 Get the IDs of all water bodies:

--- a/landa/api.py
+++ b/landa/api.py
@@ -5,10 +5,7 @@ import frappe
 
 from landa.water_body_management.change_log import ChangeLog
 from landa.water_body_management.doctype.fish_species.fish_species import get_fish_species_data
-from landa.water_body_management.doctype.water_body.water_body import (
-	build_water_body_cache,
-	build_water_body_data,
-)
+from landa.water_body_management.doctype.water_body.water_body import build_water_body_data
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])
@@ -82,20 +79,9 @@ def water_body(id: str = None, only_id: int = 0) -> List[Dict]:
 		# We do not cache ID since it's uniqueness makes the API performant
 		return build_water_body_data(id)
 
-	cache_exists = frappe.cache().hexists("water_body_data", "all")
-
-	if not cache_exists:
-		# Build the cache (for future calls)
-		build_water_body_cache()
-
 	# return the cached result
-	data = get_water_body_cache("all")
+	data = frappe.cache().get_value("water_body_data", build_water_body_data)
 	return [item["id"] for item in data] if only_id else data
-
-
-def get_water_body_cache(key: str) -> List[Dict]:
-	"""Return a **CACHED** list of water bodies with fish species and special provisions."""
-	return frappe.cache().hget("water_body_data", key)
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])

--- a/landa/api.py
+++ b/landa/api.py
@@ -76,21 +76,20 @@ def organization(id: str = None) -> List[Dict]:
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET"])
-def water_body(id: str = None, fishing_area: str = None, only_id: int = 0) -> List[Dict]:
+def water_body(id: str = None, only_id: int = 0) -> List[Dict]:
 	"""Return a list of water bodies with fish species and special provisions."""
 	if id:
 		# We do not cache ID since it's uniqueness makes the API performant
-		return build_water_body_data(id, fishing_area)
+		return build_water_body_data(id)
 
-	key = fishing_area or "all"
-	cache_exists = frappe.cache().hexists("water_body_data", key)
+	cache_exists = frappe.cache().hexists("water_body_data", "all")
 
 	if not cache_exists:
 		# Build the cache (for future calls)
-		build_water_body_cache(fishing_area)
+		build_water_body_cache()
 
 	# return the cached result
-	data = get_water_body_cache(key)
+	data = get_water_body_cache("all")
 	return [item["id"] for item in data] if only_id else data
 
 

--- a/landa/patches/build_water_body_cache.py
+++ b/landa/patches/build_water_body_cache.py
@@ -1,11 +1,5 @@
-import frappe
-
 from landa.water_body_management.doctype.water_body.water_body import build_water_body_cache
 
 
 def execute():
-	build_water_body_cache()  # Cache all Water Bodies
-
-	fishing_areas = frappe.get_all("Fishing Area", pluck="name")
-	for area in fishing_areas:
-		build_water_body_cache(fishing_area=area)  # Cache Fishing Area wise
+	build_water_body_cache()

--- a/landa/patches/build_water_body_cache.py
+++ b/landa/patches/build_water_body_cache.py
@@ -1,5 +1,5 @@
-from landa.water_body_management.doctype.water_body.water_body import build_water_body_cache
+from landa.water_body_management.doctype.water_body.water_body import rebuild_water_body_cache
 
 
 def execute():
-	build_water_body_cache()
+	rebuild_water_body_cache()

--- a/landa/water_body_management/doctype/fish_species/fish_species.py
+++ b/landa/water_body_management/doctype/fish_species/fish_species.py
@@ -24,16 +24,12 @@ def get_fish_species_data(id: str = None) -> List[Dict]:
 		# We do not cache ID since it's uniqueness makes the API performant
 		return query_fish_species_data(id)
 
-	cache_exists = frappe.cache().hexists("fish_species_data", "all")
-	if not cache_exists:
-		build_fish_species_cache()
-
-	return frappe.cache().hget("fish_species_data", "all")
+	return frappe.cache().get_value("fish_species_data", query_fish_species_data)
 
 
 def build_fish_species_cache():
 	"""Rebuild entire fish species data and set in cache."""
-	frappe.cache().hset("fish_species_data", "all", query_fish_species_data())
+	frappe.cache().set_value("fish_species_data", query_fish_species_data())
 
 
 def query_fish_species_data(id: str = None) -> List[Dict]:

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -15,11 +15,11 @@ from landa.utils import get_current_member_data
 class WaterBody(Document):
 	def on_update(self):
 		if not self.flags.skip_cache_rebuild:
-			rebuild_water_body_cache(self.fishing_area)
+			rebuild_water_body_cache()
 
 	def after_delete(self):
 		if not self.flags.skip_cache_rebuild:
-			rebuild_water_body_cache(self.fishing_area)
+			rebuild_water_body_cache()
 
 	def validate(self):
 		self.validate_edit_access()
@@ -55,20 +55,14 @@ class WaterBody(Document):
 		self.marker_tooltip = None
 
 
-def rebuild_water_body_cache(fishing_area: str = None, enqueued: bool = False):
-	"""
-	Rebuilds water body cache for all water bodies **AND** fishing area wise.
-	"""
+def rebuild_water_body_cache(enqueued: bool = False):
+	"""Rebuild cache for all Water Bodies."""
 	# Invalidate Cache
 	if enqueued:
 		frappe.cache().hset("water_body_data", "in_progress", 1)
 
 	frappe.cache().hdel("water_body_data", "all")
 	build_water_body_cache()
-
-	if fishing_area:
-		frappe.cache().hdel("water_body_data", fishing_area)
-		build_water_body_cache(fishing_area=fishing_area)
 
 	if enqueued:
 		frappe.cache().hset("water_body_data", "in_progress", 0)
@@ -132,24 +126,23 @@ def remove_past_events(cutoff_date):
 			)
 
 
-def build_water_body_cache(fishing_area: str = None):
+def build_water_body_cache():
 	"""
 	Build the water body cache for all water bodies **OR** fishing area wise.
 	"""
-	water_bodies = build_water_body_data(fishing_area=fishing_area)
-	key = fishing_area or "all"
-	frappe.cache().hset("water_body_data", key, water_bodies)
+	water_bodies = build_water_body_data()
+	frappe.cache().hset("water_body_data", "all", water_bodies)
 
 
-def build_water_body_data(id: str = None, fishing_area: str = None) -> List[Dict]:
+def build_water_body_data(id: str = None) -> List[Dict]:
 	"""
 	Return a list of water bodies with fish species and special provisions
 	"""
-	result = query_water_body_data(id=id, fishing_area=fishing_area)
+	result = query_water_body_data(id=id)
 	return consolidate_water_body_data(water_body_data=result)
 
 
-def query_water_body_data(id: str = None, fishing_area: str = None) -> List[Dict]:
+def query_water_body_data(id: str = None) -> List[Dict]:
 	water_body = frappe.qb.DocType("Water Body")
 	fish_species_table = frappe.qb.DocType("Fish Species Table")
 	wb_provision_table = frappe.qb.DocType("Water Body Special Provision Table")
@@ -196,9 +189,6 @@ def query_water_body_data(id: str = None, fishing_area: str = None) -> List[Dict
 
 	if id and isinstance(id, str):
 		query = query.where(water_body.name == id)
-
-	if fishing_area and isinstance(fishing_area, str):
-		query = query.where(water_body.fishing_area == fishing_area)
 
 	return query.run(as_dict=True)
 
@@ -329,7 +319,7 @@ def rebuild_cache_on_attachment(doc, method):
 	water_body_data = frappe.db.get_value(
 		"Water Body",
 		doc.attached_to_name,
-		["is_active", "display_in_fishing_guide", "fishing_area"],
+		["is_active", "display_in_fishing_guide"],
 		as_dict=True,
 	)
 	if not water_body_data:
@@ -342,10 +332,9 @@ def rebuild_cache_on_attachment(doc, method):
 	if method == "after_delete":
 		# NOTE:Enqueue gets uncommitted data (new thread). Files appear even if deleted
 		# Still no clue why
-		rebuild_water_body_cache(fishing_area=water_body_data.fishing_area)
+		rebuild_water_body_cache()
 	elif not frappe.cache().hget("water_body_data", "in_progress"):
 		frappe.enqueue(
 			rebuild_water_body_cache,
-			fishing_area=water_body_data.fishing_area,
 			enqueued=True,
 		)

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -14,10 +14,12 @@ from landa.utils import get_current_member_data
 
 class WaterBody(Document):
 	def on_update(self):
-		rebuild_water_body_cache(self.fishing_area)
+		if not self.flags.skip_cache_rebuild:
+			rebuild_water_body_cache(self.fishing_area)
 
 	def after_delete(self):
-		rebuild_water_body_cache(self.fishing_area)
+		if not self.flags.skip_cache_rebuild:
+			rebuild_water_body_cache(self.fishing_area)
 
 	def validate(self):
 		self.validate_edit_access()
@@ -74,8 +76,15 @@ def rebuild_water_body_cache(fishing_area: str = None, enqueued: bool = False):
 
 def remove_outdated_information():
 	cutoff_date = getdate()
+
 	remove_outdated_public_information(cutoff_date)
 	remove_past_events(cutoff_date)
+
+	frappe.enqueue(
+		rebuild_water_body_cache,
+		queue="long",
+		enqueue_after_commit=True,
+	)
 
 
 def remove_outdated_public_information(cutoff_date):
@@ -91,6 +100,7 @@ def remove_outdated_public_information(cutoff_date):
 		water_body = frappe.get_doc("Water Body", name)
 		water_body.current_public_information = None
 		water_body.current_information_expires_on = None
+		water_body.flags.skip_cache_rebuild = True
 		try:
 			water_body.save()
 		except Exception:
@@ -110,6 +120,7 @@ def remove_past_events(cutoff_date):
 		pluck="name",
 	):
 		water_body = frappe.get_doc("Water Body", name)
+		water_body.flags.skip_cache_rebuild = True
 		for event in water_body.events:
 			if event.date <= cutoff_date:
 				water_body.remove(event)

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -59,13 +59,12 @@ def rebuild_water_body_cache(enqueued: bool = False):
 	"""Rebuild cache for all Water Bodies."""
 	# Invalidate Cache
 	if enqueued:
-		frappe.cache().hset("water_body_data", "in_progress", 1)
+		frappe.cache().set_value("water_body_data_in_progress", 1)
 
-	frappe.cache().hdel("water_body_data", "all")
-	build_water_body_cache()
+	frappe.cache().set_value("water_body_data", build_water_body_data())
 
 	if enqueued:
-		frappe.cache().hset("water_body_data", "in_progress", 0)
+		frappe.cache().set_value("water_body_data_in_progress", 0)
 
 
 def remove_outdated_information():
@@ -130,8 +129,7 @@ def build_water_body_cache():
 	"""
 	Build the water body cache for all water bodies **OR** fishing area wise.
 	"""
-	water_bodies = build_water_body_data()
-	frappe.cache().hset("water_body_data", "all", water_bodies)
+	frappe.cache().set_value("water_body_data", build_water_body_data())
 
 
 def build_water_body_data(id: str = None) -> List[Dict]:
@@ -333,7 +331,7 @@ def rebuild_cache_on_attachment(doc, method):
 		# NOTE:Enqueue gets uncommitted data (new thread). Files appear even if deleted
 		# Still no clue why
 		rebuild_water_body_cache()
-	elif not frappe.cache().hget("water_body_data", "in_progress"):
+	elif not frappe.cache().get_value("water_body_data_in_progress"):
 		frappe.enqueue(
 			rebuild_water_body_cache,
 			enqueued=True,

--- a/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.py
+++ b/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.py
@@ -10,7 +10,7 @@ from landa.water_body_management.doctype.water_body.water_body import rebuild_wa
 
 class WaterBodyManagementLocalOrganization(Document):
 	def on_update(self):
-		rebuild_water_body_cache(self.fishing_area)
+		rebuild_water_body_cache()
 
 	def after_delete(self):
-		rebuild_water_body_cache(self.fishing_area)
+		rebuild_water_body_cache()


### PR DESCRIPTION
This pull request improves the efficiency and correctness of the water body cache rebuilding process by ensuring that the cache is only rebuilt when necessary. The changes prevent redundant cache rebuilds during batch updates and introduce asynchronous cache rebuilding after outdated information is removed.

Cache rebuild control:

* The `on_update` and `after_delete` methods in the `WaterBody` class now check the `skip_cache_rebuild` flag before triggering a cache rebuild, preventing unnecessary cache operations during batch updates.
* The `remove_outdated_public_information` and `remove_past_events` functions set the `skip_cache_rebuild` flag to `True` on each `WaterBody` document before saving, ensuring that cache rebuilds are skipped during these batch modifications.

Asynchronous cache maintenance:

* After outdated information and past events are removed, the `remove_outdated_information` function now enqueues a single asynchronous cache rebuild task, ensuring the cache is updated only once after all changes.

Todo:

- [x] Cache for fishing_area is not handled yet -> remove API parameter `fishing_area`?
    The Angelatlas team confirmed that this parameter is unused and can be safely removed.
- [x] So far, we used `cache().hset/hget`. This is more verbose and unsafe when multiple sites run on the same bench. Change to `cache().get_value/set_value`.

Alternative: simplify caching logic by moving to time-based `redis_cache` decorator -> rejected because it could lead to user-facing delays when cache expires.