### PR TITLE
fix(Contact): prevent linking email address to multiple LANDA Members

### DIFF
--- a/landa/locale/de.po
+++ b/landa/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LANDA VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-12-04 19:09+0053\n"
+"POT-Creation-Date: 2025-12-10 21:28+0053\n"
 "PO-Revision-Date: 2025-11-29 18:55+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -216,7 +216,7 @@ msgstr "Kann untergeordnete Vereine enthalten"
 msgid "Cannot be a member of organization {} because it is a group."
 msgstr "Kann kein Mitglied von Verein/Verband {} sein, da nur Vereine bzw. Ortsgruppen Mitglieder haben dürfen, keine Regional- und Landesverbände."
 
-#: landa/organization_management/doctype/organization/organization.py:69
+#: landa/organization_management/doctype/organization/organization.py:70
 msgid "Cannot set Parent Organization to a local group."
 msgstr ""
 
@@ -1435,7 +1435,7 @@ msgstr "Neuen Fangbucheintrag anlegen"
 msgid "New Member Function Entry"
 msgstr "Neue Mitgliedsfunktion anlegen"
 
-#: landa/organization_management/doctype/organization/organization.py:319
+#: landa/organization_management/doctype/organization/organization.py:320
 msgid "No Company found for Organization {0}."
 msgstr "Kein Bestellwesenkonto RV für Verein {0} gefunden."
 
@@ -1548,7 +1548,7 @@ msgstr "Bitte tragen Sie vor dem Buchen der Rechnung eine Rechnungsadresse ein."
 msgid "Please set a Billing Contact before submitting the Sales Invoice."
 msgstr "Bitte tragen Sie vor dem Buchen der Rechnung einen Rechnungskontakt ein."
 
-#: landa/organization_management/doctype/organization/organization.py:61
+#: landa/organization_management/doctype/organization/organization.py:62
 msgid "Please set a Parent Organization."
 msgstr "Bitte tragen Sie einen übergeordneten Verein ein."
 
@@ -1886,6 +1886,10 @@ msgstr "Das Mitglied ist nun als Kontakt dieses Vereins und des entsprechenden B
 msgid "The Member Function Category {0} can only be assigned once per organization."
 msgstr " Die Mitgliedsfunktionskategorie {0} kann nur einmal je Verein vergeben werden."
 
+#: landa/organization_management/contact/contact.py:29
+msgid "The email address {0} is already linked to another LANDA Member. Please use a different one for this contact."
+msgstr "Die E-Mail-Adresse {0} ist bereits mit einem anderen Mitglied verknüpft. Bitte verwenden Sie eine andere E-Mail-Adresse für diesen Kontakt."
+
 #: landa/organization_management/doctype/member_data_import/member_data_import.py:80
 msgid "The selected address does not belong to the selected LANDA Member"
 msgstr "Die ausgewählte Adresse gehört nicht zum ausgewählten Mitglied"
@@ -1898,15 +1902,15 @@ msgstr "Die hochgeladene Datei enthält keine Projekt-ID."
 msgid "The weight of {0} in row {1} diverges from the typical weight by more than 40 %"
 msgstr "Das Gewicht von {0} in Zeile {1} weicht um mehr als 40 % vom typischen Gewicht ab"
 
-#: landa/organization_management/doctype/organization/organization.py:315
+#: landa/organization_management/doctype/organization/organization.py:316
 msgid "There is no Customer linked to {0}."
 msgstr "Es ist kein Bestellwesenkonto mit {0} verknüpft."
 
-#: landa/organization_management/doctype/organization/organization.py:238
+#: landa/organization_management/doctype/organization/organization.py:239
 msgid "There is no single address linked to {0}."
 msgstr "Es ist keine einzelne Adresse mit {0} verknüpft."
 
-#: landa/organization_management/doctype/organization/organization.py:230
+#: landa/organization_management/doctype/organization/organization.py:231
 msgid "There is no single contact linked to {0}."
 msgstr "Es ist kein einzelner Kontakt mit {0} verknüpft."
 

--- a/landa/locale/main.pot
+++ b/landa/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LANDA VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-12-04 19:09+0053\n"
-"PO-Revision-Date: 2025-12-04 19:09+0053\n"
+"POT-Creation-Date: 2025-12-10 21:28+0053\n"
+"PO-Revision-Date: 2025-12-10 21:28+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Cannot be a member of organization {} because it is a group."
 msgstr ""
 
-#: landa/organization_management/doctype/organization/organization.py:69
+#: landa/organization_management/doctype/organization/organization.py:70
 msgid "Cannot set Parent Organization to a local group."
 msgstr ""
 
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "New Member Function Entry"
 msgstr ""
 
-#: landa/organization_management/doctype/organization/organization.py:319
+#: landa/organization_management/doctype/organization/organization.py:320
 msgid "No Company found for Organization {0}."
 msgstr ""
 
@@ -1548,7 +1548,7 @@ msgstr ""
 msgid "Please set a Billing Contact before submitting the Sales Invoice."
 msgstr ""
 
-#: landa/organization_management/doctype/organization/organization.py:61
+#: landa/organization_management/doctype/organization/organization.py:62
 msgid "Please set a Parent Organization."
 msgstr ""
 
@@ -1886,6 +1886,10 @@ msgstr ""
 msgid "The Member Function Category {0} can only be assigned once per organization."
 msgstr ""
 
+#: landa/organization_management/contact/contact.py:29
+msgid "The email address {0} is already linked to another LANDA Member. Please use a different one for this contact."
+msgstr ""
+
 #: landa/organization_management/doctype/member_data_import/member_data_import.py:80
 msgid "The selected address does not belong to the selected LANDA Member"
 msgstr ""
@@ -1898,15 +1902,15 @@ msgstr ""
 msgid "The weight of {0} in row {1} diverges from the typical weight by more than 40 %"
 msgstr ""
 
-#: landa/organization_management/doctype/organization/organization.py:315
+#: landa/organization_management/doctype/organization/organization.py:316
 msgid "There is no Customer linked to {0}."
 msgstr ""
 
-#: landa/organization_management/doctype/organization/organization.py:238
+#: landa/organization_management/doctype/organization/organization.py:239
 msgid "There is no single address linked to {0}."
 msgstr ""
 
-#: landa/organization_management/doctype/organization/organization.py:230
+#: landa/organization_management/doctype/organization/organization.py:231
 msgid "There is no single contact linked to {0}."
 msgstr ""
 

--- a/landa/organization_management/contact/contact.py
+++ b/landa/organization_management/contact/contact.py
@@ -1,9 +1,35 @@
+import frappe
+from frappe import _
 from frappe.contacts.doctype.contact.contact import Contact
 
 
 def validate(contact: Contact, event: str) -> None:
+	validate_email_address_for_member(contact)
 	set_primary_email_if_missing(contact)
 	set_primary_phone_if_missing(contact)
+
+
+def validate_email_address_for_member(contact: Contact) -> None:
+	"""Validate that the email address is not linked to another LANDA Member."""
+	user = frappe.db.get_value(
+		"User",
+		filters={"email": contact.email_id, "landa_member": ("is", "set")},
+		fieldname=["name", "landa_member"],
+		as_dict=True,
+	)
+
+	if not user:
+		return
+
+	for link in contact.links:
+		if link.link_doctype != "LANDA Member" or link.link_name == user.landa_member:
+			continue
+
+		frappe.throw(
+			_(
+				"The email address {0} is already linked to another LANDA Member. Please use a different one for this contact."
+			).format(contact.email_id)
+		)
 
 
 def set_primary_email_if_missing(contact: Contact) -> bool:


### PR DESCRIPTION
Currently, the system is designed to assign exactly one member to each user. This also applies to contacts, which automatically get assigned to a user and thus to a member via their email address. This means that all new contacts with Jane's email address automatically belong to Jane's preexisting user and thus also to her preexisting member record. The workaround for how Jane can become a member in a different organization would be to register a separate user account and/or contact with a different email address.

This restriction was previously not clear, this PR enforces it.