### PR TITLE
fix(Contact): prevent linking email address to multiple LANDA Members (backport #289)

### DIFF
--- a/landa/organization_management/contact/contact.py
+++ b/landa/organization_management/contact/contact.py
@@ -1,9 +1,35 @@
+import frappe
+from frappe import _
 from frappe.contacts.doctype.contact.contact import Contact
 
 
 def validate(contact: Contact, event: str) -> None:
+	validate_email_address_for_member(contact)
 	set_primary_email_if_missing(contact)
 	set_primary_phone_if_missing(contact)
+
+
+def validate_email_address_for_member(contact: Contact) -> None:
+	"""Validate that the email address is not linked to another LANDA Member."""
+	user = frappe.db.get_value(
+		"User",
+		filters={"email": contact.email_id, "landa_member": ("is", "set")},
+		fieldname=["name", "landa_member"],
+		as_dict=True,
+	)
+
+	if not user:
+		return
+
+	for link in contact.links:
+		if link.link_doctype != "LANDA Member" or link.link_name == user.landa_member:
+			continue
+
+		frappe.throw(
+			_(
+				"The email address {0} is already linked to another LANDA Member. Please use a different one for this contact."
+			).format(contact.email_id)
+		)
 
 
 def set_primary_email_if_missing(contact: Contact) -> bool:

--- a/landa/translations/de.csv
+++ b/landa/translations/de.csv
@@ -154,3 +154,4 @@ No Company found for Organization {0}.,Kein Bestellwesenkonto RV für Verein {0}
 Landlord Name,Verpächter,
 Payment Recipient,Zahlungsempfänger,
 You are not a member of any organization.,Sie sind kein Mitglied eines Vereins.,
+The email address {0} is already linked to another LANDA Member. Please use a different one for this contact.,Die E-Mail-Adresse {0} ist bereits mit einem anderen Mitglied verknüpft. Bitte verwenden Sie eine andere E-Mail-Adresse für diesen Kontakt.


### PR DESCRIPTION
Currently, the system is designed to assign exactly one member to each user. This also applies to contacts, which automatically get assigned to a user and thus to a member via their email address. This means that all new contacts with Jane's email address automatically belong to Jane's preexisting user and thus also to her preexisting member record. The workaround for how Jane can become a member in a different organization would be to register a separate user account and/or contact with a different email address.

This restriction was previously not clear, this PR enforces it.