### PR TITLE
fix: improve duplicate yearly fishing permit validation logic (LAN-894)

### DIFF
--- a/landa/locale/de.po
+++ b/landa/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LANDA VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-09 09:11+0053\n"
+"POT-Creation-Date: 2026-01-17 01:15+0053\n"
 "PO-Revision-Date: 2025-11-29 18:55+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -294,13 +294,13 @@ msgstr "Neue Besatzmaßnahme"
 msgid "Create Stocking Targets"
 msgstr "Besatzplanungen erstellen"
 
-#: landa/organization_management/doctype/landa_member/landa_member_list.js:79
+#: landa/organization_management/doctype/landa_member/landa_member_list.js:82
 msgid "Create Yearly Fishing Permit"
 msgstr "Erlaubnisschein erstellen"
 
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:83
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:91
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:103
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:89
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:97
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:109
 msgid "Creating Yearly Fishing Permits..."
 msgstr "Erlaubnisscheine werden erstellt..."
 
@@ -1798,7 +1798,7 @@ msgstr "Fangbegrenzung Salmonidengewässer"
 msgid "Special Yearly Fishing Permits"
 msgstr "Erlaubnisscheine Gewässerfonds"
 
-#: landa/organization_management/doctype/landa_member/landa_member_list.js:68
+#: landa/organization_management/doctype/landa_member/landa_member_list.js:71
 msgid "Special Yearly Fishing Permits cleared."
 msgstr "Erlaubnisscheine Gewässerfonds gelöscht."
 
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Year must be between {0} and {1}."
 msgstr "Jahr muss zwischen {0} und {1} liegen."
 
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:65
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:71
 msgid "Year must be either the current year or the next year."
 msgstr "Jahr muss entweder das aktuelle Jahr oder das nächste Jahr sein."
 
@@ -2276,9 +2276,9 @@ msgstr "Erlaubnisschein Info Text"
 msgid "Yearly Fishing Permit Type"
 msgstr "Erlaubnisscheinart"
 
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:57
-msgid "Yearly Fishing Permit already exists for member {0} and year {1}. Please cancel the existing permit before creating a new one."
-msgstr "Erlaubnisschein für Mitglied {0} und Jahr {1} existiert bereits. Bitte stornieren Sie den bestehenden Erlaubnisschein, bevor Sie einen neuen erstellen."
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:63
+msgid "Yearly Fishing Permit already exists for member {0} and year {1}. Please delete or cancel the existing permit before creating a new one."
+msgstr "Erlaubnisschein für Mitglied {0} und Jahr {1} existiert bereits. Bitte löschen oder stornieren Sie den bestehenden Erlaubnisschein, bevor Sie einen neuen erstellen."
 
 #. Name of a report
 #. Label of a Link in the Organization Management Workspace
@@ -2287,7 +2287,7 @@ msgstr "Erlaubnisschein für Mitglied {0} und Jahr {1} existiert bereits. Bitte 
 msgid "Yearly Fishing Permits Issued"
 msgstr "Vergebene Erlaubnisscheine"
 
-#: landa/organization_management/doctype/landa_member/landa_member_list.js:110
+#: landa/organization_management/doctype/landa_member/landa_member_list.js:113
 msgid "Yearly Fishing Permits have been created for {0} members."
 msgstr "Erlaubnisscheine für {0} Mitglieder wurden erstellt."
 

--- a/landa/locale/main.pot
+++ b/landa/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LANDA VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-09 09:11+0053\n"
-"PO-Revision-Date: 2026-01-09 09:11+0053\n"
+"POT-Creation-Date: 2026-01-17 01:15+0053\n"
+"PO-Revision-Date: 2026-01-17 01:15+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -294,13 +294,13 @@ msgstr ""
 msgid "Create Stocking Targets"
 msgstr ""
 
-#: landa/organization_management/doctype/landa_member/landa_member_list.js:79
+#: landa/organization_management/doctype/landa_member/landa_member_list.js:82
 msgid "Create Yearly Fishing Permit"
 msgstr ""
 
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:83
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:91
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:103
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:89
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:97
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:109
 msgid "Creating Yearly Fishing Permits..."
 msgstr ""
 
@@ -1798,7 +1798,7 @@ msgstr ""
 msgid "Special Yearly Fishing Permits"
 msgstr ""
 
-#: landa/organization_management/doctype/landa_member/landa_member_list.js:68
+#: landa/organization_management/doctype/landa_member/landa_member_list.js:71
 msgid "Special Yearly Fishing Permits cleared."
 msgstr ""
 
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Year must be between {0} and {1}."
 msgstr ""
 
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:65
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:71
 msgid "Year must be either the current year or the next year."
 msgstr ""
 
@@ -2276,8 +2276,8 @@ msgstr ""
 msgid "Yearly Fishing Permit Type"
 msgstr ""
 
-#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:57
-msgid "Yearly Fishing Permit already exists for member {0} and year {1}. Please cancel the existing permit before creating a new one."
+#: landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py:63
+msgid "Yearly Fishing Permit already exists for member {0} and year {1}. Please delete or cancel the existing permit before creating a new one."
 msgstr ""
 
 #. Name of a report
@@ -2287,7 +2287,7 @@ msgstr ""
 msgid "Yearly Fishing Permits Issued"
 msgstr ""
 
-#: landa/organization_management/doctype/landa_member/landa_member_list.js:110
+#: landa/organization_management/doctype/landa_member/landa_member_list.js:113
 msgid "Yearly Fishing Permits have been created for {0} members."
 msgstr ""
 

--- a/landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py
+++ b/landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py
@@ -51,11 +51,17 @@ class YearlyFishingPermit(Document):
 
 		if frappe.db.exists(
 			"Yearly Fishing Permit",
-			{"member": self.member, "year": self.year, "docstatus": 1, "type": ("in", duplicate_types)},
+			{
+				"name": ("!=", self.name),
+				"member": self.member,
+				"year": self.year,
+				"docstatus": ("!=", 2),
+				"type": ("in", duplicate_types),
+			},
 		):
 			frappe.throw(
 				_(
-					"Yearly Fishing Permit already exists for member {0} and year {1}. Please cancel the existing permit before creating a new one."
+					"Yearly Fishing Permit already exists for member {0} and year {1}. Please delete or cancel the existing permit before creating a new one."
 				).format(self.member, self.year),
 				exc=frappe.DuplicateEntryError,
 			)


### PR DESCRIPTION
This pull request updates the validation logic for yearly fishing permits to improve duplicate detection and provide clearer user guidance. The main change is to ensure that when checking for existing permits, the current document is excluded, and permits with any status except "cancelled" are considered duplicates.

Validation logic improvements:

* The duplicate check in `validate` now excludes the current permit (`name != self.name`) and considers any permit that is not cancelled (`docstatus != 2`), ensuring more accurate detection of duplicates.
* The error message shown to users has been updated to instruct them to "delete or cancel" existing permits, making the required action clearer.