### PR TITLE
fix: set Organization in bulk creation of fishing permits

### DIFF
--- a/landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py
+++ b/landa/organization_management/doctype/yearly_fishing_permit/yearly_fishing_permit.py
@@ -100,6 +100,7 @@ def bulk_create(permit_type: str, year: str, members: str):
 		)
 		yfp = frappe.new_doc("Yearly Fishing Permit")
 		yfp.member = member
+		yfp.organization = frappe.db.get_value("LANDA Member", member, "organization")
 		yfp.year = year
 		yfp.type = permit_type
 		yfp.insert()


### PR DESCRIPTION
This is required for User Permissions to work correctly.
