### PR TITLE
fix(External Contact): allow linking to state organization

### DIFF
--- a/landa/organization_management/doctype/external_contact/external_contact.js
+++ b/landa/organization_management/doctype/external_contact/external_contact.js
@@ -6,7 +6,7 @@ frappe.ui.form.on("External Contact", {
 		frm.set_query("organization", function () {
 			return {
 				filters: {
-					parent_organization: "LV",
+					parent_organization: ["in", [frappe.boot.landa?.state_organization, ""]],
 				},
 			};
 		});


### PR DESCRIPTION
Update the `organization` field query in `external_contact.js` to filter organizations where `parent_organization` is either the current state organization (from `frappe.boot.landa?.state_organization`) or empty, instead of hardcoding "LV".