### PR TITLE
fix(Firebase Settings): store credentials in database instead of filesystem (#330)

### DIFF
--- a/landa/firebase_connector.py
+++ b/landa/firebase_connector.py
@@ -5,8 +5,8 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 
 class FirebaseNotification:
-	def __init__(self, cert, project_id):
-		self.cert = cert
+	def __init__(self, credentials_info: dict, project_id: str):
+		self.credentials_info = credentials_info
 		self.url = f"https://fcm.googleapis.com/v1/projects/{project_id}/messages:send"
 		self.token = self._get_access_token()
 
@@ -15,8 +15,8 @@ class FirebaseNotification:
 
 		:return: Access token.
 		"""
-		credentials = service_account.Credentials.from_service_account_file(
-			self.cert,
+		credentials = service_account.Credentials.from_service_account_info(
+			self.credentials_info,
 			scopes=[
 				"https://www.googleapis.com/auth/cloud-platform",
 				"https://www.googleapis.com/auth/firebase",

--- a/landa/water_body_management/doctype/firebase_settings/firebase_settings.js
+++ b/landa/water_body_management/doctype/firebase_settings/firebase_settings.js
@@ -14,16 +14,12 @@ frappe.ui.form.on("Firebase Settings", {
 				restrictions: {
 					allowed_file_types: [".json"],
 				},
-				on_success: function ({ data }) {
+				on_success: function () {
 					frappe.show_alert({
 						message: __("Firebase credentials uploaded successfully"),
 						indicator: "green",
 					});
-					frm.set_value("project_id", data.project_id);
-					if (frm.is_dirty()) {
-						// project id might be unchanged
-						frm.save();
-					}
+					frm.reload_doc();
 				},
 			});
 		});

--- a/landa/water_body_management/doctype/firebase_settings/firebase_settings.json
+++ b/landa/water_body_management/doctype/firebase_settings/firebase_settings.json
@@ -9,7 +9,9 @@
   "enable_firebase_notifications",
   "firebase_topic",
   "column_break_sidox",
-  "project_id"
+  "project_id",
+  "section_break_nxri",
+  "credentials"
  ],
  "fields": [
   {
@@ -36,13 +38,23 @@
    "fieldtype": "Data",
    "label": "Project ID",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_nxri",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "credentials",
+   "fieldtype": "Password",
+   "label": "Credentials",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-12-04 18:55:21.862767",
+ "modified": "2026-06-19 16:17:58.901383",
  "modified_by": "Administrator",
  "module": "Water Body Management",
  "name": "Firebase Settings",

--- a/landa/water_body_management/doctype/firebase_settings/firebase_settings.py
+++ b/landa/water_body_management/doctype/firebase_settings/firebase_settings.py
@@ -54,7 +54,6 @@ def upload_api_file(*args, **kwargs):
 			title=_("Missing Project ID"),
 		)
 
-	doc = frappe.get_single("Firebase Settings")
 	doc.project_id = project_id
 	doc.credentials = json.dumps(json_data)
 	doc.save()

--- a/landa/water_body_management/doctype/firebase_settings/firebase_settings.py
+++ b/landa/water_body_management/doctype/firebase_settings/firebase_settings.py
@@ -2,7 +2,6 @@
 # For license information, please see license.txt
 import json
 from io import BytesIO
-from pathlib import Path
 
 import frappe
 from frappe import _
@@ -18,6 +17,7 @@ class FirebaseSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		credentials: DF.Password | None
 		enable_firebase_notifications: DF.Check
 		firebase_topic: DF.Data | None
 		project_id: DF.Data | None
@@ -37,17 +37,14 @@ class FirebaseSettings(Document):
 			)
 
 	@property
-	def credentials_path(self):
-		return get_crendentials_path()
-
-	@property
 	def has_credentials(self):
-		return self.credentials_path.exists()
+		return bool(self.get_password("credentials", raise_exception=False))
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def upload_api_file(*args, **kwargs):
-	frappe.has_permission("Firebase Settings", "write", throw=True)
+	doc = frappe.get_single("Firebase Settings")
+	doc.check_permission("write")
 
 	json_data = json.load(BytesIO(frappe.local.uploaded_file))
 	project_id = json_data.get("project_id")
@@ -57,12 +54,9 @@ def upload_api_file(*args, **kwargs):
 			title=_("Missing Project ID"),
 		)
 
-	credentials_path = get_crendentials_path()
-	credentials_path.parent.mkdir(exist_ok=True)
-	credentials_path.write_text(json.dumps(json_data, indent=1))
+	doc = frappe.get_single("Firebase Settings")
+	doc.project_id = project_id
+	doc.credentials = json.dumps(json_data)
+	doc.save()
 
 	return {"doctype": "File", "data": {"project_id": project_id}}
-
-
-def get_crendentials_path():
-	return Path(frappe.local.site_path) / "firebase" / "credentials.json"

--- a/landa/water_body_management/utils.py
+++ b/landa/water_body_management/utils.py
@@ -55,13 +55,10 @@ def create_firebase_notification(doc, event):
 		# firebase doesn't allow nested objects
 		change_log["changes"] = json.dumps(change_log["changes"])
 
-	credentials_info = json.loads(firebase_settings.get_password("credentials"))
-
 	# Send notification to topic
 	frappe.enqueue(
 		send_firebase_notification,
 		queue="default",
-		credentials_info=credentials_info,
 		project_id=firebase_settings.project_id,
 		topic=firebase_settings.firebase_topic,
 		change_log=change_log,
@@ -69,9 +66,15 @@ def create_firebase_notification(doc, event):
 	)
 
 
-def send_firebase_notification(credentials_info, project_id, topic, change_log):
+def send_firebase_notification(project_id, topic, change_log):
 	try:
-		fcm = FirebaseNotification(credentials_info, project_id)
+		credentials = frappe.get_single("Firebase Settings").get_password(
+			"credentials", raise_exception=False
+		)
+		if not credentials:
+			return
+
+		fcm = FirebaseNotification(json.loads(credentials), project_id)
 		fcm.send_to_topic(topic, change_log)
 	except Exception:
 		frappe.log_error(

--- a/landa/water_body_management/utils.py
+++ b/landa/water_body_management/utils.py
@@ -55,11 +55,13 @@ def create_firebase_notification(doc, event):
 		# firebase doesn't allow nested objects
 		change_log["changes"] = json.dumps(change_log["changes"])
 
+	credentials_info = json.loads(firebase_settings.get_password("credentials"))
+
 	# Send notification to topic
 	frappe.enqueue(
 		send_firebase_notification,
 		queue="default",
-		file_path=firebase_settings.credentials_path,
+		credentials_info=credentials_info,
 		project_id=firebase_settings.project_id,
 		topic=firebase_settings.firebase_topic,
 		change_log=change_log,
@@ -67,9 +69,9 @@ def create_firebase_notification(doc, event):
 	)
 
 
-def send_firebase_notification(file_path, project_id, topic, change_log):
+def send_firebase_notification(credentials_info, project_id, topic, change_log):
 	try:
-		fcm = FirebaseNotification(file_path, project_id)
+		fcm = FirebaseNotification(credentials_info, project_id)
 		fcm.send_to_topic(topic, change_log)
 	except Exception:
 		frappe.log_error(


### PR DESCRIPTION
This pull request updates how Firebase credentials are managed and stored in the application, moving from using a credentials file on disk to securely storing credentials in the database. The changes affect both the backend logic and the user interface for uploading and handling Firebase credentials.

**Credential Management Improvements:**

* Changed `FirebaseNotification` to accept credentials as a dictionary (`credentials_info`) instead of a file path, and updated token retrieval to use `from_service_account_info` for in-memory credentials handling. 
* Updated the `Firebase Settings` DocType to store credentials as an encrypted field (`credentials`) in the database, and removed file path logic. 

**User Interface and API Changes:**

* Modified the credentials upload handler to save credentials directly to the database and reload the form, rather than saving to a file and updating only the project ID.

**Notification Sending Logic:**

* Updated notification logic to retrieve credentials from the database and pass them as a dictionary to the notification sender, removing all file-based credential handling.