### PR TITLE
fix(Organization): create permissions (LAN-906)

### DIFF
--- a/landa/organization_management/doctype/organization/organization.json
+++ b/landa/organization_management/doctype/organization/organization.json
@@ -83,6 +83,7 @@
    "options": "Organization"
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "parent_organization",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
@@ -249,7 +250,7 @@
    "link_fieldname": "organization"
   }
  ],
- "modified": "2026-05-30 19:17:07.406605",
+ "modified": "2026-06-25 16:20:07.802703",
  "modified_by": "Administrator",
  "module": "Organization Management",
  "name": "Organization",

--- a/landa/organization_management/doctype/organization/organization.py
+++ b/landa/organization_management/doctype/organization/organization.py
@@ -11,7 +11,6 @@ from frappe.contacts.address_and_contact import (
 )
 from frappe.desk.treeview import make_tree_args
 from frappe.model.naming import make_autoname, revert_series_if_last
-from frappe.permissions import has_permission
 from frappe.utils.data import cint, get_link_to_form
 from frappe.utils.nestedset import NestedSet
 

--- a/landa/organization_management/doctype/organization/organization.py
+++ b/landa/organization_management/doctype/organization/organization.py
@@ -75,7 +75,15 @@ class Organization(NestedSet):
 			self.create_company()
 		elif self.is_level(2):
 			# Local Organizations
-			self.create_customer()
+
+			# Enqueue so that organization already exists when the customer is
+			# created and permissions check works.
+			frappe.enqueue(
+				create_customer,
+				enqueue_after_commit=True,
+				organization_id=self.name,
+				organization_name=self.organization_name,
+			)
 
 		# Clear user permissions cache, so users can work with the new
 		# Organization right away. If we don't do this, users will get a
@@ -131,20 +139,6 @@ class Organization(NestedSet):
 			return n == 0
 		else:
 			return frappe.get_doc(self.doctype, self.parent_organization).is_level(n - 1)
-
-	def create_customer(self):
-		"""Create a Customer corresponding to this organization."""
-		# check permission here so we can ignore it later
-		self.check_permission_on_parent("create")
-
-		customer = frappe.new_doc("Customer")
-		# Name (ID) of Customer is determined by customer_name on insert ...
-		customer.customer_name = self.name
-		customer.organization = self.name
-		customer.insert(ignore_permissions=True)
-		# ... so we can set the correct value only after insertion.
-		customer.customer_name = self.organization_name
-		customer.save(ignore_permissions=True)
 
 	def create_company(self):
 		def create_bank_account(bank_account, account_number, company_name):
@@ -210,17 +204,6 @@ class Organization(NestedSet):
 			frappe.get_value("Company", company.name, "default_cash_account"),
 		)
 
-	def check_permission_on_parent(self, ptype):
-		"""Check if current user has `ptype` permission on parent Organization.
-
-		User Permission check against this DocType will fail during initial creation.
-		Therefore we check if we have permission on the parent doctype and can safely
-		ignore permissions afterwards.
-		"""
-		parent_organization = frappe.get_doc("Organization", self.parent_organization)
-		if not has_permission("Organization", ptype=ptype, doc=parent_organization):
-			frappe.throw(_("Not permitted"), frappe.PermissionError)
-
 	@frappe.whitelist()
 	def link_contact(self, landa_member: str, is_default_billing: int = 0, is_default_shipping: int = 0):
 		self.has_permission("write")
@@ -253,6 +236,19 @@ class Organization(NestedSet):
 			customer.default_shipping_address = address.name
 
 		customer.save()
+
+
+def create_customer(organization_id: str, organization_name: str):
+	"""Create a Customer corresponding to this organization."""
+	# check permission here so we can ignore it later
+	customer = frappe.new_doc("Customer")
+	# Name (ID) of Customer is determined by customer_name on insert ...
+	customer.customer_name = organization_id
+	customer.organization = organization_id
+	customer.insert()
+	# ... so we can set the correct value only after insertion.
+	customer.customer_name = organization_name
+	customer.save()
 
 
 def add_links(address_or_contact, organization: str):
@@ -295,9 +291,7 @@ def add_node():
 	if args.parent_organization == "All Organizations":
 		args.parent_organization = None
 
-	doc = frappe.get_doc(args)
-	doc.check_permission_on_parent("create")
-	doc.insert(ignore_permissions=True)
+	frappe.get_doc(args).insert()
 
 
 def get_supported_water_bodies(organization: str) -> list[str]:

--- a/landa/organization_management/doctype/organization/organization.py
+++ b/landa/organization_management/doctype/organization/organization.py
@@ -240,15 +240,19 @@ class Organization(NestedSet):
 
 def create_customer(organization_id: str, organization_name: str):
 	"""Create a Customer corresponding to this organization."""
-	# check permission here so we can ignore it later
-	customer = frappe.new_doc("Customer")
-	# Name (ID) of Customer is determined by customer_name on insert ...
-	customer.customer_name = organization_id
-	customer.organization = organization_id
-	customer.insert()
-	# ... so we can set the correct value only after insertion.
-	customer.customer_name = organization_name
-	customer.save()
+	if customer_id := frappe.db.exists("Customer", {"organization": organization_id}):
+		customer = frappe.get_doc("Customer", customer_id)
+	else:
+		customer = frappe.new_doc("Customer")
+		# Name (ID) of Customer is determined by customer_name on insert ...
+		customer.customer_name = organization_id
+		customer.organization = organization_id
+		customer.insert()
+
+	if customer.customer_name != organization_name:
+		# ... so we can set the correct value only after insertion.
+		customer.customer_name = organization_name
+		customer.save()
 
 
 def add_links(address_or_contact, organization: str):


### PR DESCRIPTION
- Organization usually needs a parent -> show field in quick entry.
- Auto-creation of linked Customer: since current doc is not created yet, the user permissions check fails.
    -> Instead of ignoring permissions, enqueue the job so it runs at a time when Organization exists.
    Parent doc check was a bad workaround that can be dropped.
