### PR TITLE
feat(Water Body Local Organization): add read perms for members

### DIFF
--- a/landa/water_body_management/doctype/water_body/water_body.js
+++ b/landa/water_body_management/doctype/water_body/water_body.js
@@ -41,6 +41,72 @@ frappe.ui.form.on("Water Body", {
 				},
 			};
 		});
+
+		frm.trigger("render_water_body_management_local_organizations");
+	},
+	render_water_body_management_local_organizations: function (frm) {
+		// Copying the HTML structure from frappe/frappe/public/js/frappe/form/grid.js here
+		// to make it look like the other grids.
+		const orgs = frm.doc.__onload.water_body_management_local_organizations;
+		const rows = orgs
+			.map(
+				(org) => `<div class="grid-row">
+				<div class="data-row row">
+					<div class="col grid-static-col col-xs-6" data-fieldname="organization" data-fieldtype="Link">
+						<div class="static-area ellipsis">
+							<a
+								href="${frappe.utils.escape_html(frappe.router.make_url(["organization", org.organization]))}"
+								target="_blank"
+							>
+								${frappe.utils.escape_html(org.organization_name)}
+							</a>
+						</div>
+					</div>
+					<div class="col grid-static-col col-xs-6" data-fieldname="note" data-fieldtype="Small Text">
+						<div class="static-area ellipsis">${frappe.utils.escape_html(org.note || "")}</div>
+					</div>
+				</div>
+			</div>`,
+			)
+			.join("");
+
+		frm.fields_dict.water_body_management_local_organizations.wrapper.innerHTML = `
+	<div class="grid-field">
+		<label class="control-label" for="water_body_management_local_organizations_grid">
+			${__("Water Body Management Local Organizations")}
+		</label>
+		<div class="form-grid-container" id="water_body_management_local_organizations_grid">
+			<div class="form-grid">
+				<div class="grid-heading-row">
+					<div class="grid-row">
+						<div class="data-row row">
+							<div class="col grid-static-col col-xs-6" data-fieldname="organization" data-fieldtype="Link">
+								<div class="static-area ellipsis">${__("Organization")}</div>
+							</div>
+							<div class="col grid-static-col col-xs-6" data-fieldname="note" data-fieldtype="Small Text">
+								<div class="static-area ellipsis">${__("Note")}</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="grid-body">
+					<div class="rows">${rows}</div>
+					${
+						orgs.length
+							? ""
+							: `<div class="grid-empty text-center">
+								<img
+									src="/assets/frappe/images/ui-states/grid-empty-state.svg"
+									alt="Grid Empty State"
+									class="grid-empty-illustration"
+								>
+								${__("No Data")}
+							</div>`
+					}
+				</div>
+			</div>
+		</div>
+	</div>`;
 	},
 	location: function (frm) {
 		frm.trigger("update_draw");

--- a/landa/water_body_management/doctype/water_body/water_body.js
+++ b/landa/water_body_management/doctype/water_body/water_body.js
@@ -47,7 +47,7 @@ frappe.ui.form.on("Water Body", {
 	render_water_body_management_local_organizations: function (frm) {
 		// Copying the HTML structure from frappe/frappe/public/js/frappe/form/grid.js here
 		// to make it look like the other grids.
-		const orgs = frm.doc.__onload.water_body_management_local_organizations;
+		const orgs = (frm.doc.__onload || {}).water_body_management_local_organizations || [];
 		const rows = orgs
 			.map(
 				(org) => `<div class="grid-row">

--- a/landa/water_body_management/doctype/water_body/water_body.json
+++ b/landa/water_body_management/doctype/water_body/water_body.json
@@ -25,6 +25,7 @@
   "current_public_information",
   "current_information_expires_on",
   "events",
+  "water_body_management_local_organizations",
   "water_body_size_section",
   "water_body_size",
   "column_break_7",
@@ -287,6 +288,10 @@
    "fieldtype": "Table",
    "label": "Events",
    "options": "LANDA Event"
+  },
+  {
+   "fieldname": "water_body_management_local_organizations",
+   "fieldtype": "HTML"
   }
  ],
  "grid_page_length": 50,
@@ -304,11 +309,11 @@
    "link_fieldname": "water_body"
   }
  ],
- "modified": "2025-12-04 18:55:20.476051",
+ "modified": "2026-07-03 17:16:55.918967",
  "modified_by": "Administrator",
  "module": "Water Body Management",
  "name": "Water Body",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/landa/water_body_management/doctype/water_body/water_body.py
+++ b/landa/water_body_management/doctype/water_body/water_body.py
@@ -62,6 +62,18 @@ class WaterBody(Document):
 		water_body_special_provisions: DF.Table[WaterBodySpecialProvisionTable]
 
 	# end: auto-generated types
+	def onload(self):
+		self.set_onload(
+			"water_body_management_local_organizations", self.get_water_body_management_local_organizations()
+		)
+
+	def get_water_body_management_local_organizations(self):
+		return frappe.get_all(
+			"Water Body Management Local Organization",
+			filters={"water_body": self.name, "disabled": 0},
+			fields=["organization", "organization_name", "note"],
+		)
+
 	def on_update(self):
 		if not self.flags.skip_cache_rebuild:
 			rebuild_water_body_cache()

--- a/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.json
+++ b/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.json
@@ -35,7 +35,6 @@
    "depends_on": "regional_organization",
    "fieldname": "organization",
    "fieldtype": "Link",
-   "ignore_user_permissions": 1,
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Organization",
@@ -47,8 +46,7 @@
    "fieldname": "water_body_local_contact_table",
    "fieldtype": "Table",
    "label": "Water Body Local Contact Table",
-   "options": "Water Body Local Contact Table",
-   "permlevel": 1
+   "options": "Water Body Local Contact Table"
   },
   {
    "fetch_from": "water_body.title",
@@ -110,7 +108,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-07-03 16:32:22.758211",
+ "modified": "2026-07-03 15:40:59.342662",
  "modified_by": "Administrator",
  "module": "Water Body Management",
  "name": "Water Body Management Local Organization",
@@ -129,12 +127,6 @@
    "write": 1
   },
   {
-   "permlevel": 1,
-   "read": 1,
-   "role": "System Manager",
-   "write": 1
-  },
-  {
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -148,12 +140,6 @@
    "write": 1
   },
   {
-   "permlevel": 1,
-   "read": 1,
-   "role": "LANDA State Organization Employee",
-   "write": 1
-  },
-  {
    "create": 1,
    "delete": 1,
    "export": 1,
@@ -165,26 +151,11 @@
    "write": 1
   },
   {
-   "permlevel": 1,
-   "read": 1,
-   "role": "LANDA Regional Water Body Management",
-   "write": 1
-  },
-  {
    "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "LANDA Local Water Body Management"
-  },
-  {
-   "permlevel": 1,
-   "read": 1,
-   "role": "LANDA Local Water Body Management"
-  },
-  {
-   "read": 1,
-   "role": "LANDA Member"
   }
  ],
  "row_format": "Dynamic",

--- a/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.json
+++ b/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.json
@@ -35,6 +35,7 @@
    "depends_on": "regional_organization",
    "fieldname": "organization",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Organization",
@@ -46,7 +47,8 @@
    "fieldname": "water_body_local_contact_table",
    "fieldtype": "Table",
    "label": "Water Body Local Contact Table",
-   "options": "Water Body Local Contact Table"
+   "options": "Water Body Local Contact Table",
+   "permlevel": 1
   },
   {
    "fetch_from": "water_body.title",
@@ -108,7 +110,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-07-03 15:40:59.342662",
+ "modified": "2026-07-03 16:32:22.758211",
  "modified_by": "Administrator",
  "module": "Water Body Management",
  "name": "Water Body Management Local Organization",
@@ -127,6 +129,12 @@
    "write": 1
   },
   {
+   "permlevel": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -137,6 +145,12 @@
    "report": 1,
    "role": "LANDA State Organization Employee",
    "share": 1,
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "LANDA State Organization Employee",
    "write": 1
   },
   {
@@ -151,11 +165,26 @@
    "write": 1
   },
   {
+   "permlevel": 1,
+   "read": 1,
+   "role": "LANDA Regional Water Body Management",
+   "write": 1
+  },
+  {
    "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "LANDA Local Water Body Management"
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "LANDA Local Water Body Management"
+  },
+  {
+   "read": 1,
+   "role": "LANDA Member"
   }
  ],
  "row_format": "Dynamic",

--- a/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.json
+++ b/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.json
@@ -9,6 +9,7 @@
  "field_order": [
   "water_body",
   "organization",
+  "note",
   "column_break_4",
   "water_body_title",
   "organization_name",
@@ -98,11 +99,16 @@
    "fieldname": "members_section",
    "fieldtype": "Section Break",
    "label": "Members"
+  },
+  {
+   "fieldname": "note",
+   "fieldtype": "Small Text",
+   "label": "Note"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-12-04 18:55:22.456211",
+ "modified": "2026-07-03 15:40:59.342662",
  "modified_by": "Administrator",
  "module": "Water Body Management",
  "name": "Water Body Management Local Organization",

--- a/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.py
+++ b/landa/water_body_management/doctype/water_body_management_local_organization/water_body_management_local_organization.py
@@ -23,6 +23,7 @@ class WaterBodyManagementLocalOrganization(Document):
 
 		disabled: DF.Check
 		fishing_area: DF.Link | None
+		note: DF.SmallText | None
 		organization: DF.Link
 		organization_name: DF.Data | None
 		regional_organization: DF.Link | None


### PR DESCRIPTION
## Summary

This PR makes it visible on **Water Body** which local organization is responsible for maintaining a water body, without exposing members or contact data.

The previous permission-based approach was reverted because it had an unwanted side effect: water body managers from one organization could potentially see contacts from another organization. Instead, **Water Body** now loads and renders only the responsible organization name and optional _Note_.

## Changes

- Shows responsible local organizations directly on **Water Body**.
- Adds the optional _Note_ field to document maintained sections or other responsibility details.
- Loads only the organization name and note needed for display.
- Reverts broad member read permissions on **Water Body Management Local Organization** to avoid exposing contact data across organizations.

## Test Plan

- [x] Verify that a member can see the responsible organization name on a water body.
- [x] Verify that a member can see responsible organizations outside their own organization.
- [x] Verify that a member can see the optional note when maintained sections are documented.
- [x] Verify that members cannot see contacts or member details from other organizations.
- [x] Verify that regional users can maintain the optional note.